### PR TITLE
Fixes #14

### DIFF
--- a/metadata/rest/test/test_transactioninfo.py
+++ b/metadata/rest/test/test_transactioninfo.py
@@ -22,7 +22,7 @@ class TestTransactionInfoAPI(CPCommonTest):
             '{0}/transactioninfo/by_id/{1}'.format(self.url, transaction_id))
         self.assertEqual(req.status_code, 200)
         req_json = loads(req.text)
-        self.assertEqual(str(req_json['id']), str(transaction_id))
+        self.assertEqual(str(req_json['_id']), str(transaction_id))
 
         # test search with multiple return
         search_terms = {


### PR DESCRIPTION
This should clean up the transaction info block returns

### Description

I'm rearranging the return data from the transaction queries to better show the different types of metadata returned (basic/required vs user-specified key/values)

### Issues Resolved

#14 

### Check List

- [X] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
