### PR TITLE
Fixes #16

### DIFF
--- a/metadata/rest/instrument_queries/instrument_term_search.py
+++ b/metadata/rest/instrument_queries/instrument_term_search.py
@@ -16,6 +16,8 @@ class InstrumentTermSearch(QueryBase):
     def search_for_instrument(search_term):
         """Return a dictionary containing information about a given instrument."""
         terms = re.findall(r'[^+ ,;]+', search_term)
+        if not terms:
+            return []
         keys = ['display_name', 'name_short', 'name', 'id']
         where_clause = Expression(1, OP.EQ, 1)
         for item in terms:

--- a/metadata/rest/test/test_instrumentinfo.py
+++ b/metadata/rest/test/test_instrumentinfo.py
@@ -68,6 +68,12 @@ class TestObjectInfoAPI(CPCommonTest):
         req = self._search_for_instrument(search_term)
         self.assertEqual(req.status_code, 404)
 
+        # test instrument search with empty search term
+        search_term = ''
+        req = self._search_for_instrument(search_term)
+        self.assertEqual(req.status_code, 200)
+        self.assertEqual(req.text, '[]')
+
         # test get instruments for user
         user_id = 11
         req = self._get_instruments_for_user(user_id=user_id)


### PR DESCRIPTION
Should clear up the cases where the full list of instruments is returned for an empty search term list

### Description

Alters the behavior of the instrument search call, such that sending an empty set of search terms returns an empty list of instruments, not the entire bloody thing.

### Issues Resolved

#16 

### Check List

- [X] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
