### PR TITLE
fix #15 update size to be elasticsearch long

### DIFF
--- a/metadata/elastic/test/test_elastic.py
+++ b/metadata/elastic/test/test_elastic.py
@@ -18,7 +18,7 @@ class TestElastic(TestCase):
             elastic_mapping = orm_cls.elastic_mapping()
             self.assertEqual(type(elastic_mapping), dict)
             properties = elastic_mapping['properties']
-            elastic_mapping_types = ['integer', 'string', 'date', 'boolean', 'float']
+            elastic_mapping_types = ['integer', 'string', 'date', 'boolean', 'float', 'long']
             for column in properties.keys():
                 self.assertEqual(properties[column]['type'] in elastic_mapping_types, True)
 # pylint: enable=too-few-public-methods

--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -57,8 +57,8 @@ class Files(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Files, Files).elastic_mapping_builder(obj)
-        obj['transaction_id'] = obj['size'] = \
-            {'type': 'integer'}
+        obj['transaction_id'] = {'type': 'integer'}
+        obj['size'] = {'type': 'long'}
         obj['ctime'] = obj['mtime'] = \
             {'type': 'date', 'format': 'yyyy-mm-dd\'T\'HH:mm:ss'}
         obj['name'] = obj['subdir'] = obj['mimetype'] = \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 cherrypy
 codeclimate-test-reporter
 coverage
-docker-py
 elasticsearch
 httpretty
 nose

--- a/test_files/files.json
+++ b/test_files/files.json
@@ -15,7 +15,7 @@
     "mimetype": "text/plain",
     "mtime": "Sat Nov 12 21:38:21 2016",
     "name": "bar.txt",
-    "size": 234,
+    "size": 3221225472,
     "subdir": "a/b",
     "transaction_id": 67
   }


### PR DESCRIPTION
### Description

This should make the size field of a file a long for elasticsearch
matching the BigIntegerField peewee type.
### Issues Resolved

#15 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
