### PR TITLE
Instrumentinfo query now returns empty set rather than 404

### DIFF
--- a/metadata/rest/instrument_queries/instrument_user_search.py
+++ b/metadata/rest/instrument_queries/instrument_user_search.py
@@ -1,5 +1,4 @@
 """CherryPy Status Metadata object class."""
-import cherrypy
 from cherrypy import tools
 from metadata.orm import Instruments, ProposalParticipant, ProposalInstrument
 from metadata.rest.instrument_queries.query_base import QueryBase
@@ -26,12 +25,8 @@ class InstrumentUserSearch(QueryBase):
                                  on=(ProposalInstrument.instrument == Instruments.id))
                            .join(ProposalParticipant,
                                  on=(ProposalParticipant.proposal == ProposalInstrument.proposal))
-                           .where(where_clause))
-        if len(instrument_list) == 0:
-            message = 'No instrument entries were retrieved the requested user'
-            raise cherrypy.HTTPError(
-                '404 No Valid Instruments Located', message)
-
+                           .where(where_clause)
+                           .order_by(Instruments.display_name))
         return [QueryBase.format_instrument_block(obj) for obj in instrument_list]
 
     # pylint: disable=invalid-name

--- a/metadata/rest/test/test_instrumentinfo.py
+++ b/metadata/rest/test/test_instrumentinfo.py
@@ -77,4 +77,5 @@ class TestObjectInfoAPI(CPCommonTest):
         # test get instruments for user
         user_id = 11
         req = self._get_instruments_for_user(user_id=user_id)
-        self.assertEqual(req.status_code, 404)
+        self.assertEqual(req.status_code, 200)
+        self.assertEqual(req.text, '[]')


### PR DESCRIPTION
Fixes #36

### Description

Changes the return for the instrumentinfo/by_user_id to provide an empty result set instead of a 404 when no instruments are found

### Issues Resolved

#36 

### Check List

- [X] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
