### PR TITLE
Issue 36 instrumentinfo query fix

### DIFF
--- a/metadata/rest/instrument_queries/instrument_user_search.py
+++ b/metadata/rest/instrument_queries/instrument_user_search.py
@@ -1,5 +1,4 @@
 """CherryPy Status Metadata object class."""
-import cherrypy
 from cherrypy import tools
 from metadata.orm import Instruments, ProposalParticipant, ProposalInstrument
 from metadata.rest.instrument_queries.query_base import QueryBase
@@ -26,12 +25,8 @@ class InstrumentUserSearch(QueryBase):
                                  on=(ProposalInstrument.instrument == Instruments.id))
                            .join(ProposalParticipant,
                                  on=(ProposalParticipant.proposal == ProposalInstrument.proposal))
-                           .where(where_clause))
-        if len(instrument_list) == 0:
-            message = 'No instrument entries were retrieved the requested user'
-            raise cherrypy.HTTPError(
-                '404 No Valid Instruments Located', message)
-
+                           .where(where_clause)
+                           .order_by(Instruments.display_name))
         return [QueryBase.format_instrument_block(obj) for obj in instrument_list]
 
     # pylint: disable=invalid-name

--- a/metadata/rest/reporting_queries/summarize_by_date.py
+++ b/metadata/rest/reporting_queries/summarize_by_date.py
@@ -64,11 +64,8 @@ class SummarizeByDate(QueryBase):
             }
         }
 
-        raw_results = {d['id']: d for d in query.dicts()}
-
         for item in query:
-            results['day_graph']['by_date'] = SummarizeByDate._summarize_by_date(
-                results['day_graph']['by_date'], item, raw_results)
+            SummarizeByDate._summarize_by_date(results['day_graph']['by_date'], item)
 
             results['transaction_info']['transaction'][item.transaction.id] = item.transaction.to_hash()
             results['transaction_info']['proposal'][item.transaction.proposal.id] = item.transaction.proposal.title
@@ -97,11 +94,9 @@ class SummarizeByDate(QueryBase):
             upload_stats_block['user'][item.transaction.submitter.id] = 0
         upload_stats_block['user'][item.transaction.submitter.id] += 1
 
-        return upload_stats_block
-
     @staticmethod
-    def _summarize_by_date(summary_block, item, raw_results):
-        current_day = SummarizeByDate._utc_to_local(raw_results[item.id]['filedate']).date()
+    def _summarize_by_date(summary_block, item):
+        current_day = SummarizeByDate._utc_to_local(item.mtime).date()
         current_day = current_day.strftime('%Y-%m-%d')
         if current_day not in summary_block['file_count'].keys():
             summary_block['file_count'][current_day] = 0
@@ -114,7 +109,7 @@ class SummarizeByDate(QueryBase):
         if item.transaction_id not in summary_block['transactions'][current_day]:
             summary_block['transactions'][current_day].append(item.transaction.id)
 
-        return summary_block
+        # return summary_block
 
     @staticmethod
     def _local_to_utc(local_datetime_obj):

--- a/metadata/rest/reporting_queries/summarize_by_date.py
+++ b/metadata/rest/reporting_queries/summarize_by_date.py
@@ -71,8 +71,7 @@ class SummarizeByDate(QueryBase):
                 transaction_cache[item.transaction_id] = t_info
             else:
                 t_info = transaction_cache[item.transaction_id]
-            results['day_graph']['by_date'] = SummarizeByDate._summarize_by_date(
-                results['day_graph']['by_date'], item)
+            SummarizeByDate._summarize_by_date(results['day_graph']['by_date'], item)
 
             SummarizeByDate._update_transaction_info_block(results['transaction_info'], item, t_info)
 

--- a/metadata/rest/test/test_instrumentinfo.py
+++ b/metadata/rest/test/test_instrumentinfo.py
@@ -77,4 +77,5 @@ class TestObjectInfoAPI(CPCommonTest):
         # test get instruments for user
         user_id = 11
         req = self._get_instruments_for_user(user_id=user_id)
-        self.assertEqual(req.status_code, 404)
+        self.assertEqual(req.status_code, 200)
+        self.assertEqual(req.text, '[]')

--- a/metadata/rest/user_queries/user_search.py
+++ b/metadata/rest/user_queries/user_search.py
@@ -28,7 +28,7 @@ class UserSearch(QueryBase):
                         where_clause_part |= Expression(
                             Users.id, OP.EQ, user_term)
                         where_clause_part |= (
-                            fn.TO_CHAR(Users.id, '999999').contains(user_term)
+                            fn.TO_CHAR(Users.id, '99999999999').contains(user_term)
                         )
                 else:
                     where_clause_part |= (


### PR DESCRIPTION
### Description

When searching for instruments and users by ID, the search engine massages the integer values to make them string-like so that you can search them as if they actually were strings. The function that carries this out is Postgres native, and requires a formatting term to carry out the process. The formatter that I picked was only good for numbers up to 999999, but the ID's used for the Dēmo instantiation were 7 digits, not 6. Expanded the formatted to handle numbers up to 99999999999.

### Issues Resolved

#36 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable