### PR TITLE
Remove the colon query mechanism for determining the instrument group

### DIFF
--- a/metadata/rest/instrument_queries/query_base.py
+++ b/metadata/rest/instrument_queries/query_base.py
@@ -8,7 +8,7 @@ class QueryBase(object):
 
     @staticmethod
     def format_instrument_block(instrument_entry):
-        """Construct a dictionary from a given proposal instance in the metadata stack."""
+        """Construct a dictionary from a given instrument instance in the metadata stack."""
         _ie = instrument_entry
         g_names = Groups.select(
             Groups.name

--- a/metadata/rest/instrument_queries/query_base.py
+++ b/metadata/rest/instrument_queries/query_base.py
@@ -1,5 +1,6 @@
 """CherryPy Status Metadata proposalinfo base class."""
-import re
+from metadata.orm.instrument_group import InstrumentGroup
+from metadata.orm.groups import Groups
 
 
 class QueryBase(object):
@@ -9,15 +10,22 @@ class QueryBase(object):
     def format_instrument_block(instrument_entry):
         """Construct a dictionary from a given proposal instance in the metadata stack."""
         _ie = instrument_entry
-        name_components = re.search(r'(.+):\s*(.+)', str(_ie.name))
-        category = name_components.group(1) if name_components is not None else 'Miscellaneous'
-        name = name_components.group(2) if name_components is not None else _ie.name
+        g_names = Groups.select(
+            Groups.name
+        ).join(
+            InstrumentGroup
+        ).where(
+            InstrumentGroup.instrument_id == _ie.id
+        )
+        category = g_names[0].name if g_names else 'Miscellaneous'
+        name = _ie.name
         display_name = '[{0} / ID:{1}] {2}'.format(
             category, _ie.id, name
         )
         return {
             'id': _ie.id,
             'category': category,
+            'groups': [g.name for g in g_names],
             'display_name': display_name,
             'name': name,
             'name_short': _ie.name_short,

--- a/metadata/rest/test/test_userinfo.py
+++ b/metadata/rest/test/test_userinfo.py
@@ -49,7 +49,7 @@ class TestUserInfoAPI(CPCommonTest):
         user = req_json.pop()
         self.assertEqual(user['person_id'], user_id)
 
-        # test search with eus id
+        # test search with user id
         search_terms = '10'
         req = requests.get(
             '{0}/userinfo/search/{1}'.format(self.url, search_terms))

--- a/metadata/rest/user_queries/query_base.py
+++ b/metadata/rest/user_queries/query_base.py
@@ -24,7 +24,7 @@ class QueryBase(object):
             prop_id = prop.id
             clean_proposals[prop_id] = info
 
-        display_name = '[EUS ID {0}] {1} {2} &lt;{3}&gt;'.format(
+        display_name = '[User ID {0}] {1} {2} &lt;{3}&gt;'.format(
             user_entry.id,
             user_hash.get('first_name'),
             user_hash.get('last_name'),


### PR DESCRIPTION
### Description

This uses the appropriate instrument group relationship for determining
the category and the groups for the instrument.

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
