### PR TITLE
add Elasticsearch sniffing options to try retrying uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache: pip
 addons:
   apt:
     sources:
-      - elasticsearch-5.5
+      - elasticsearch-5.x
     packages:
       - elasticsearch
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,13 @@ matrix:
       env: RUN_LINTS=true
 cache: pip
 
+addons:
+  apt:
+    sources:
+      - elasticsearch-5.5
+    packages:
+      - elasticsearch
+
 before_install: bash -xe travis/before-install.sh
 install: pip install -r requirements-dev.txt
 script: bash -xe travis/test-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
       - elasticsearch-5.x
     packages:
       - elasticsearch
+      - oracle-java8-set-default
 
 before_install: bash -xe travis/before-install.sh
 install: pip install -r requirements-dev.txt

--- a/metadata/elastic/orm.py
+++ b/metadata/elastic/orm.py
@@ -7,18 +7,24 @@ from metadata.elastic import ELASTIC_ENDPOINT, ELASTIC_INDEX
 class ElasticAPI(object):
     """Elastic search conversion and interface methods."""
 
+    es_kwargs = {
+        'sniff_on_start': True,
+        'sniff_on_connection_fail': True,
+        'sniffer_timeout': 60
+    }
+
     @classmethod
     def elastic_delete(cls, obj):
         """Delete the object for the class in elastic search."""
         class_name = obj.__class__.__name__
         obj_id = obj.id
-        esclient = Elasticsearch([ELASTIC_ENDPOINT])
+        esclient = Elasticsearch([ELASTIC_ENDPOINT], **cls.es_kwargs)
         esclient.delete(ELASTIC_INDEX, class_name, obj_id)
 
     @classmethod
     def elastic_upload(cls, objs):
         """Upload the object for the class to elastic search."""
-        esclient = Elasticsearch([ELASTIC_ENDPOINT])
+        esclient = Elasticsearch([ELASTIC_ENDPOINT], **cls.es_kwargs)
         class_name = cls.__name__
         clean_oper = []
         for obj in objs:
@@ -47,7 +53,7 @@ class ElasticAPI(object):
         { body }
         """
         class_name = cls.__name__
-        esclient = Elasticsearch([ELASTIC_ENDPOINT])
+        esclient = Elasticsearch([ELASTIC_ENDPOINT], **cls.es_kwargs)
         esclient.indices.put_mapping(class_name, cls.elastic_mapping())
 
     @staticmethod

--- a/metadata/elastic/orm.py
+++ b/metadata/elastic/orm.py
@@ -53,7 +53,7 @@ class ElasticAPI(object):
         { body }
         """
         class_name = cls.__name__
-        esclient = Elasticsearch([ELASTIC_ENDPOINT], **cls.es_kwargs)
+        esclient = Elasticsearch([ELASTIC_ENDPOINT])
         esclient.indices.put_mapping(class_name, cls.elastic_mapping())
 
     @staticmethod

--- a/metadata/elastic/test/__init__.py
+++ b/metadata/elastic/test/__init__.py
@@ -1,2 +1,22 @@
 #!/usr/bin/python
 """Tests for the Elastic Search module."""
+
+ES_CLUSTER_BODY = {
+    'cluster_name': 'elasticsearch',
+    'nodes': {
+        'qQooKRbMTbqhyaTx_qWQmw': {
+            'name': 'Ivan Kragoff',
+            'transport_address': '127.0.0.1:9300',
+            'host': '127.0.0.1',
+            'ip': '127.0.0.1',
+            'version': '2.4.5',
+            'build': 'c849dd1',
+            'http_address': '127.0.0.1:9200',
+            'http': {
+                'bound_address': ['0.0.0.0:9200'],
+                'publish_address': '127.0.0.1:9200',
+                'max_content_length_in_bytes': 104857600
+            }
+        }
+    }
+}

--- a/metadata/elastic/test/test_api.py
+++ b/metadata/elastic/test/test_api.py
@@ -5,6 +5,7 @@ from json import dumps, loads
 import httpretty
 from metadata.orm.utils import unicode_type
 from metadata.elastic.orm import ElasticAPI
+from metadata.elastic.test import ES_CLUSTER_BODY
 
 
 class TestElasticAPI(TestCase):
@@ -35,6 +36,9 @@ class TestElasticAPI(TestCase):
                 }
             ]
         }
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         httpretty.register_uri(httpretty.HEAD, url, status=404)
         httpretty.register_uri(httpretty.POST, 'http://127.0.0.1:9200/_bulk',
                                body=dumps(response_body),
@@ -51,6 +55,9 @@ class TestElasticAPI(TestCase):
     @httpretty.activate
     def test_failed_upload(self):
         """Test the upload class method failed upload."""
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         obj_hash = {
             '_id': 127,
             u'foo': u'bar'
@@ -75,6 +82,9 @@ class TestElasticAPI(TestCase):
         response_body = {
             'status': 'deleted!'
         }
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         httpretty.register_uri(httpretty.DELETE, url,
                                body=dumps(response_body),
                                content_type='application/json')
@@ -90,6 +100,9 @@ class TestElasticAPI(TestCase):
         response_body = {
             'status': 'error!'
         }
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         httpretty.register_uri(httpretty.DELETE, url,
                                body=dumps(response_body),
                                content_type='application/json',
@@ -111,6 +124,9 @@ class TestElasticAPI(TestCase):
         response_body = {
             'status': 'mapped!'
         }
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         httpretty.register_uri(httpretty.PUT, url,
                                body=dumps(response_body),
                                content_type='application/json')
@@ -126,6 +142,9 @@ class TestElasticAPI(TestCase):
         response_body = {
             'status': 'error!'
         }
+        httpretty.register_uri(httpretty.GET, 'http://127.0.0.1:9200/_nodes/_all/http',
+                               body=dumps(ES_CLUSTER_BODY),
+                               content_type='application/json')
         httpretty.register_uri(httpretty.PUT, url,
                                body=dumps(response_body),
                                content_type='application/json',


### PR DESCRIPTION
### Description

This adds sniffing to the Elasticsearch client library. This should hopefully help the client inspect the elasticsearch cluster and find a node that will allow uploads quicker.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
