### PR TITLE
this is a quick fix seems doing a get() on a hash returns null

### DIFF
--- a/metadata/rest/tkvinfo_queries/values_for_key.py
+++ b/metadata/rest/tkvinfo_queries/values_for_key.py
@@ -19,7 +19,7 @@ class ValuesForKey(object):
         """Retrieve all the tkv values for a given key item."""
         # get the id of the key to look for
         val_list = (Values
-                    .select(TransactionKeyValue.transaction)
+                    .select(Values.value, TransactionKeyValue.transaction)
                     .join(TransactionKeyValue)
                     .join(Keys)
                     .where(Keys.key == key)).dicts()


### PR DESCRIPTION
### Description

When a `get()` is done on a hash it will return `null` if the key doesn't exist.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
