### PR TITLE
switch out all the string mappings for keywords where appropriate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: 5bf6c09bfa1297d3692cadd621ef95f1284e33c0
+    sha: v0.9.1
     hooks:
     -   id: trailing-whitespace
     -   id: flake8

--- a/metadata/elastic/test/test_elastic.py
+++ b/metadata/elastic/test/test_elastic.py
@@ -18,7 +18,7 @@ class TestElastic(TestCase):
             elastic_mapping = orm_cls.elastic_mapping()
             self.assertEqual(type(elastic_mapping), dict)
             properties = elastic_mapping['properties']
-            elastic_mapping_types = ['integer', 'string', 'date', 'boolean', 'float', 'long']
+            elastic_mapping_types = ['integer', 'text', 'keyword', 'date', 'boolean', 'float', 'long']
             for column in properties.keys():
                 self.assertEqual(properties[column]['type'] in elastic_mapping_types, True)
 # pylint: enable=too-few-public-methods

--- a/metadata/orm/analytical_tools.py
+++ b/metadata/orm/analytical_tools.py
@@ -26,7 +26,7 @@ class AnalyticalTools(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(AnalyticalTools, AnalyticalTools).elastic_mapping_builder(obj)
-        obj['name'] = obj['encoding'] = {'type': 'string'}
+        obj['name'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/atool_proposal.py
+++ b/metadata/orm/atool_proposal.py
@@ -37,7 +37,7 @@ class AToolProposal(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(AToolProposal, AToolProposal).elastic_mapping_builder(obj)
-        obj['proposal_id'] = {'type': 'string'}
+        obj['proposal_id'] = {'type': 'keyword'}
         obj['analytical_tool_id'] = {'type': 'integer'}
 
     def to_hash(self):

--- a/metadata/orm/citation_proposal.py
+++ b/metadata/orm/citation_proposal.py
@@ -38,7 +38,7 @@ class CitationProposal(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(CitationProposal, CitationProposal).elastic_mapping_builder(obj)
         obj['citation_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'string'}
+        obj['proposal_id'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/citations.py
+++ b/metadata/orm/citations.py
@@ -59,9 +59,11 @@ class Citations(CherryPyAPI):
         super(Citations, Citations).elastic_mapping_builder(obj)
         obj['journal_id'] = obj['journal_volume'] = \
             obj['journal_issue'] = {'type': 'integer'}
-        obj['article_title'] = obj['abstract_text'] = obj['xml_text'] = \
-            obj['page_range'] = obj['doi_reference'] = obj['release_authorization_id'] = \
-            obj['encoding'] = {'type': 'string'}
+        obj['abstract_text'] = obj['xml_text'] = \
+            obj['page_range'] = obj['release_authorization_id'] = \
+            {'type': 'string'}
+        obj['article_title'] = obj['encoding'] = \
+            obj['doi_reference'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the citation fields to a serializable hash."""

--- a/metadata/orm/citations.py
+++ b/metadata/orm/citations.py
@@ -61,7 +61,7 @@ class Citations(CherryPyAPI):
             obj['journal_issue'] = {'type': 'integer'}
         obj['abstract_text'] = obj['xml_text'] = \
             obj['page_range'] = obj['release_authorization_id'] = \
-            {'type': 'string'}
+            {'type': 'text'}
         obj['article_title'] = obj['encoding'] = \
             obj['doi_reference'] = {'type': 'keyword'}
 

--- a/metadata/orm/contributors.py
+++ b/metadata/orm/contributors.py
@@ -52,7 +52,7 @@ class Contributors(CherryPyAPI):
         super(Contributors, Contributors).elastic_mapping_builder(obj)
         obj['person_id'] = obj['institution_id'] = {'type': 'integer'}
         obj['first_name'] = obj['middle_initial'] = obj['last_name'] = \
-            obj['dept_code'] = obj['encoding'] = {'type': 'string'}
+            obj['dept_code'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object fields into a serializable hash."""

--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -63,7 +63,7 @@ class Files(CherryPyAPI):
             {'type': 'date', 'format': 'yyyy-mm-dd\'T\'HH:mm:ss'}
         obj['name'] = obj['subdir'] = obj['mimetype'] = \
             obj['encoding'] = {'type': 'keyword'}
-        obj['hashsum'] = obj['hashtype'] = {'type': 'string'}
+        obj['hashsum'] = obj['hashtype'] = {'type': 'text'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -62,8 +62,8 @@ class Files(CherryPyAPI):
         obj['ctime'] = obj['mtime'] = \
             {'type': 'date', 'format': 'yyyy-mm-dd\'T\'HH:mm:ss'}
         obj['name'] = obj['subdir'] = obj['mimetype'] = \
-            obj['encoding'] = obj['hashsum'] = \
-            obj['hashtype'] = {'type': 'string'}
+            obj['encoding'] = {'type': 'keyword'}
+        obj['hashsum'] = obj['hashtype'] = {'type': 'string'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/groups.py
+++ b/metadata/orm/groups.py
@@ -29,7 +29,7 @@ class Groups(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Groups, Groups).elastic_mapping_builder(obj)
-        obj['name'] = obj['encoding'] = {'type': 'string'}
+        obj['name'] = obj['encoding'] = {'type': 'keyword'}
         obj['is_admin'] = {'type': 'boolean'}
 
     def to_hash(self):

--- a/metadata/orm/institutions.py
+++ b/metadata/orm/institutions.py
@@ -33,7 +33,7 @@ class Institutions(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(Institutions, Institutions).elastic_mapping_builder(obj)
         obj['name'] = obj['association_cd'] = \
-            obj['encoding'] = {'type': 'string'}
+            obj['encoding'] = {'type': 'keyword'}
         obj['is_foreign'] = {'type': 'boolean'}
 
     def to_hash(self):

--- a/metadata/orm/instruments.py
+++ b/metadata/orm/instruments.py
@@ -36,7 +36,7 @@ class Instruments(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(Instruments, Instruments).elastic_mapping_builder(obj)
         obj['display_name'] = obj['name'] = obj['name_short'] = \
-            obj['encoding'] = {'type': 'string'}
+            obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/journals.py
+++ b/metadata/orm/journals.py
@@ -32,7 +32,7 @@ class Journals(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Journals, Journals).elastic_mapping_builder(obj)
-        obj['name'] = obj['website_url'] = obj['encoding'] = {'type': 'string'}
+        obj['name'] = obj['website_url'] = obj['encoding'] = {'type': 'keyword'}
         obj['impact_factor'] = {'type': 'float'}
 
     def to_hash(self):

--- a/metadata/orm/keys.py
+++ b/metadata/orm/keys.py
@@ -26,7 +26,7 @@ class Keys(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Keys, Keys).elastic_mapping_builder(obj)
-        obj['key'] = obj['encoding'] = {'type': 'string'}
+        obj['key'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/keywords.py
+++ b/metadata/orm/keywords.py
@@ -28,7 +28,7 @@ class Keywords(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Keywords, Keywords).elastic_mapping_builder(obj)
-        obj['keyword'] = obj['encoding'] = {'type': 'string'}
+        obj['keyword'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposal_instrument.py
+++ b/metadata/orm/proposal_instrument.py
@@ -38,7 +38,7 @@ class ProposalInstrument(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(ProposalInstrument, ProposalInstrument).elastic_mapping_builder(obj)
         obj['instrument_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'string'}
+        obj['proposal_id'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposal_participant.py
+++ b/metadata/orm/proposal_participant.py
@@ -38,7 +38,7 @@ class ProposalParticipant(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(ProposalParticipant, ProposalParticipant).elastic_mapping_builder(obj)
         obj['person_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'string'}
+        obj['proposal_id'] = {'type': 'text'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposal_participant.py
+++ b/metadata/orm/proposal_participant.py
@@ -38,7 +38,7 @@ class ProposalParticipant(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(ProposalParticipant, ProposalParticipant).elastic_mapping_builder(obj)
         obj['person_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'text'}
+        obj['proposal_id'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposals.py
+++ b/metadata/orm/proposals.py
@@ -54,7 +54,7 @@ class Proposals(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Proposals, Proposals).elastic_mapping_builder(obj)
-        obj['abstract'] = {'type': 'string'}
+        obj['abstract'] = {'type': 'text'}
         obj['title'] = obj['science_theme'] = obj['proposal_type'] = \
             obj['encoding'] = {'type': 'keyword'}
 

--- a/metadata/orm/proposals.py
+++ b/metadata/orm/proposals.py
@@ -54,8 +54,9 @@ class Proposals(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Proposals, Proposals).elastic_mapping_builder(obj)
-        obj['title'] = obj['abstract'] = obj['science_theme'] = obj['proposal_type'] = \
-            obj['encoding'] = {'type': 'string'}
+        obj['abstract'] = {'type': 'string'}
+        obj['title'] = obj['science_theme'] = obj['proposal_type'] = \
+            obj['encoding'] = {'type': 'keyword'}
 
         obj['submitted_date'] = \
             {'type': 'date', 'format': "yyyy-mm-dd'T'HH:mm:ss"}

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -34,7 +34,7 @@ class Transactions(CherryPyAPI):
         super(Transactions, Transactions).elastic_mapping_builder(obj)
         obj['submitter'] = {'type': 'integer'}
         obj['instrument'] = {'type': 'integer'}
-        obj['proposal'] = {'type': 'string'}
+        obj['proposal'] = {'type': 'text'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -34,7 +34,7 @@ class Transactions(CherryPyAPI):
         super(Transactions, Transactions).elastic_mapping_builder(obj)
         obj['submitter'] = {'type': 'integer'}
         obj['instrument'] = {'type': 'integer'}
-        obj['proposal'] = {'type': 'text'}
+        obj['proposal'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/users.py
+++ b/metadata/orm/users.py
@@ -39,7 +39,7 @@ class Users(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(Users, Users).elastic_mapping_builder(obj)
         obj['first_name'] = obj['last_name'] = obj['network_id'] = \
-            obj['middle_initial'] = obj['encoding'] = {'type': 'string'}
+            obj['middle_initial'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/values.py
+++ b/metadata/orm/values.py
@@ -26,7 +26,7 @@ class Values(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(Values, Values).elastic_mapping_builder(obj)
-        obj['value'] = obj['encoding'] = {'type': 'string'}
+        obj['value'] = obj['encoding'] = {'type': 'keyword'}
 
     def to_hash(self):
         """Convert the object to a hash."""


### PR DESCRIPTION
### Description

This changes out all the string elasticsearch mappings (which default to 'text') to keywords so they can be aggregated in elastic search.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
