### PR TITLE
Updating Elasticsearch docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,22 @@
 version: '2'
+
 services:
   elasticmaster:
     build:
       context: .
       dockerfile: docker-compose/Dockerfile.elastic
+    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
     container_name: elasticmaster
+    environment:
+      - cluster.name=pacifica-cluster
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
     ports:
       - 9200:9200
 
@@ -12,11 +24,18 @@ services:
     build:
       context: .
       dockerfile: docker-compose/Dockerfile.elastic
-    links:
-     - elasticmaster
+    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
     environment:
-      UNICAST_HOST: elasticmaster
-      EXCLUDE_PORTS: 9300
+      - cluster.name=pacifica-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+      - discovery.zen.ping.unicast.hosts=elasticmaster
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
 
   elasticlb:
     image: dockercloud/haproxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     build:
       context: .
       dockerfile: docker-compose/Dockerfile.elastic
-    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
     environment:
       - cluster.name=pacifica-cluster
       - bootstrap.memory_lock=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       dockerfile: docker-compose/Dockerfile.elastic
-    # image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
     container_name: elasticmaster
     environment:
       - cluster.name=pacifica-cluster

--- a/docker-compose/Dockerfile.elastic
+++ b/docker-compose/Dockerfile.elastic
@@ -1,6 +1,9 @@
 # Pull base image.
-FROM elasticsearch:2.4
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.5.1
 
-# Install HEAD plugin
-RUN ./bin/plugin install mobz/elasticsearch-head
-CMD ["-Des.discovery.zen.ping.unicast.hosts=elasticmaster", "-Des.discovery.zen.ping.multicast.enabled=false"]
+# Deal with cross-site scripting issues
+RUN touch /usr/share/elasticsearch/config/elasticsearch.yml \
+    && echo "http.cors.enabled : true" >> /usr/share/elasticsearch/config/elasticsearch.yml \
+    && echo "http.cors.allow-origin: \"/.*/\"" >> /usr/share/elasticsearch/config/elasticsearch.yml \
+    && echo "http.cors.allow-methods : OPTIONS, HEAD, GET, POST, PUT, DELETE" >> /usr/share/elasticsearch/config/elasticsearch.yml \
+    && echo "http.cors.allow-headers : \"X-Requested-With,X-Auth-Token,Content-Type, Content-Length, Authorization\"" >> /usr/share/elasticsearch/config/elasticsearch.yml


### PR DESCRIPTION
Changing docker-compose file to use the official ES 5.5.1 image from elasticsearch.co and to include the bits that allow cross-site requests to be made for testing

### Description

This changes the docker-compose.yml file to include options that are proper for ES 5.5, but are broken/changed from 2.4

### Issues Resolved

Fixes #61 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
