### PR TITLE
remove docker python onbuild as its not recommended for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM python:2-onbuild
+FROM python:2
+
+WORKDIR /usr/src/app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir uwsgi
+COPY . .
 EXPOSE 8121
-CMD [ "python", "./MetadataServer.py" ]
+ENTRYPOINT [ "/bin/bash", "/usr/src/app/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+uwsgi \
+  --http-socket 0.0.0.0:8121 \
+  --master \
+  --die-on-term \
+  --wsgi-file /usr/src/app/MetadataServer.py "$@"


### PR DESCRIPTION
### Description

This removes the docker python onbuild dependency for containers.
### Issues Resolved

N/A
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
