### PR TITLE
this fixes the elastic mapping to be text primary and have keywords also

### DIFF
--- a/metadata/orm/atool_proposal.py
+++ b/metadata/orm/atool_proposal.py
@@ -37,7 +37,7 @@ class AToolProposal(CherryPyAPI):
     def elastic_mapping_builder(obj):
         """Build the elasticsearch mapping bits."""
         super(AToolProposal, AToolProposal).elastic_mapping_builder(obj)
-        obj['proposal_id'] = {'type': 'keyword'}
+        obj['proposal_id'] = {'type': 'text', 'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}}}
         obj['analytical_tool_id'] = {'type': 'integer'}
 
     def to_hash(self):

--- a/metadata/orm/citation_proposal.py
+++ b/metadata/orm/citation_proposal.py
@@ -38,7 +38,7 @@ class CitationProposal(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(CitationProposal, CitationProposal).elastic_mapping_builder(obj)
         obj['citation_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'keyword'}
+        obj['proposal_id'] = {'type': 'text', 'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}}}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposal_instrument.py
+++ b/metadata/orm/proposal_instrument.py
@@ -38,7 +38,7 @@ class ProposalInstrument(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(ProposalInstrument, ProposalInstrument).elastic_mapping_builder(obj)
         obj['instrument_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'keyword'}
+        obj['proposal_id'] = {'type': 'text', 'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}}}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/proposal_participant.py
+++ b/metadata/orm/proposal_participant.py
@@ -38,7 +38,7 @@ class ProposalParticipant(CherryPyAPI):
         """Build the elasticsearch mapping bits."""
         super(ProposalParticipant, ProposalParticipant).elastic_mapping_builder(obj)
         obj['person_id'] = {'type': 'integer'}
-        obj['proposal_id'] = {'type': 'keyword'}
+        obj['proposal_id'] = {'type': 'text', 'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}}}
 
     def to_hash(self):
         """Convert the object to a hash."""

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -34,7 +34,7 @@ class Transactions(CherryPyAPI):
         super(Transactions, Transactions).elastic_mapping_builder(obj)
         obj['submitter'] = {'type': 'integer'}
         obj['instrument'] = {'type': 'integer'}
-        obj['proposal'] = {'type': 'keyword'}
+        obj['proposal'] = {'type': 'text', 'fields': {'keyword': {'type': 'keyword', 'ignore_above': 256}}}
 
     def to_hash(self):
         """Convert the object to a hash."""


### PR DESCRIPTION
### Description

This reverts the change to make things keyword for elasticsearch types this should allow the addition of keywords to be added to existing elasticsearch mappings when they were type text.
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
