### PR TITLE
reduce recursive queries on base checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.9.1
+    sha: v0.9.5
     hooks:
     -   id: trailing-whitespace
     -   id: flake8

--- a/metadata/orm/base.py
+++ b/metadata/orm/base.py
@@ -107,7 +107,7 @@ class PacificaModel(Model):
                 ret.append(attr)
         return ret
 
-    def to_hash(self, recursion_depth=1):
+    def to_hash(self, recursion_depth=0):
         """Convert the base object fields into serializable attributes in a hash."""
         obj = {}
         obj['created'] = self.created.isoformat()

--- a/metadata/rest/orm.py
+++ b/metadata/rest/orm.py
@@ -28,7 +28,7 @@ class CherryPyAPI(PacificaModel, ElasticAPI):
 
     @staticmethod
     def _check_recursion_depth(kwargs):
-        recursion_depth = int(kwargs.get('recursion_depth', 1))
+        recursion_depth = int(kwargs.get('recursion_depth', 0))
         if recursion_depth not in range(0, 2):
             raise ValueError('Recursion depth must be in the range of 0->2.')
         return recursion_depth

--- a/metadata/rest/orm.py
+++ b/metadata/rest/orm.py
@@ -53,10 +53,10 @@ class CherryPyAPI(PacificaModel, ElasticAPI):
             self._update_dep_objs(obj, updated_objs)
         if not did_something:
             raise HTTPError(500, "Get args didn't select any objects.")
-        complete_objs = [obj.to_hash() for obj in self.select().where(self.where_clause(kwargs))]
+        complete_objs = [obj.to_hash(1) for obj in self.select().where(self.where_clause(kwargs))]
         self.elastic_upload(complete_objs)
         for obj in updated_objs:
-            obj.elastic_upload([obj.to_hash()])
+            obj.elastic_upload([obj.to_hash(1)])
 
     def _set_or_create(self, insert_json):
         """Set or create the object if it doesn't already exist."""
@@ -69,7 +69,7 @@ class CherryPyAPI(PacificaModel, ElasticAPI):
                 obj_hash['id'] = obj_hash.pop('_id')
             obj, created = self.get_or_create(**obj_hash)
             if created:
-                complete_objs.append(obj.to_hash())
+                complete_objs.append(obj.to_hash(1))
         self.elastic_upload(complete_objs)
 
     def _insert(self, insert_json):
@@ -100,7 +100,7 @@ class CherryPyAPI(PacificaModel, ElasticAPI):
         es_objs = []
         insert_query = self.__class__.insert_many(clean_objs['upload_objs']).returning(self.__class__)
         for item in insert_query.execute():
-            es_objs.append(item.to_hash())
+            es_objs.append(item.to_hash(1))
         self.elastic_upload(es_objs)
 
     @classmethod
@@ -125,8 +125,8 @@ class CherryPyAPI(PacificaModel, ElasticAPI):
             if '_id' in obj.keys():
                 obj['id'] = obj['_id']
             self.from_hash(obj)
-            new_obj = self.to_hash()
-            es_obj = self.to_hash()
+            new_obj = self.to_hash(1)
+            es_obj = self.to_hash(1)
             fix_dates(obj, new_obj, es_obj)
             clean_objs['es_objs'].append(es_obj)
 


### PR DESCRIPTION
### Description

This roles back the default recursion depth to the default 0 and adds the recursion at 1 for elastic search uploading and updating
### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
