### PR TITLE
fix to_hash() methods to add default recursion depth

### DIFF
--- a/metadata/rest/fileinfo_queries/files_with_tkv.py
+++ b/metadata/rest/fileinfo_queries/files_with_tkv.py
@@ -29,7 +29,7 @@ class FilesWithTransactionKeyValue(object):
             # invalid value
             return []
 
-        return [f.to_hash() for f in files_query]
+        return [f.to_hash(0) for f in files_query]
 
     # Cherrypy requires these named methods.
     # pylint: disable=invalid-name

--- a/metadata/rest/reporting_queries/summarize_by_date.py
+++ b/metadata/rest/reporting_queries/summarize_by_date.py
@@ -67,7 +67,7 @@ class SummarizeByDate(QueryBase):
         transaction_cache = {}
         for item in query.iterator():
             if item.transaction_id not in transaction_cache:
-                t_info = item.transaction.to_hash()
+                t_info = item.transaction.to_hash(0)
                 transaction_cache[item.transaction_id] = t_info
             else:
                 t_info = transaction_cache[item.transaction_id]

--- a/metadata/rest/transaction_queries/query_base.py
+++ b/metadata/rest/transaction_queries/query_base.py
@@ -40,7 +40,7 @@ class QueryBase(object):
                       .where(where_clause)
                       .order_by(Files.name))
 
-        return {f.id: f.to_hash() for f in files_list}
+        return {f.id: f.to_hash(0) for f in files_list}
 
     @staticmethod
     def _get_transaction_info_block(transaction_id, option='details'):
@@ -53,7 +53,7 @@ class QueryBase(object):
                                 .where(where_clause)
                                 .get())
 
-            transaction_entry = transaction_info.to_hash()
+            transaction_entry = transaction_info.to_hash(0)
         except DoesNotExist:
             message = 'No Transaction with an ID of {0} was found'.format(
                 transaction_id)
@@ -88,7 +88,7 @@ class QueryBase(object):
 
         for trans in transactions:
             kv_list = {}
-            entry = trans.to_hash()
+            entry = trans.to_hash(0)
             metadata = QueryBase._get_base_transaction_metadata(entry, option)
             transaction = {}
             kvs = QueryBase._get_transaction_key_values(trans.id)
@@ -151,13 +151,13 @@ class QueryBase(object):
         if option == 'details':
             submitter = Users.get(
                 Users.id == transaction_entry.get('submitter')
-            ).to_hash()
+            ).to_hash(0)
             proposal = Proposals.get(
                 Proposals.id == transaction_entry.get('proposal')
-            ).to_hash()
+            ).to_hash(0)
             instrument = Instruments.get(
                 Instruments.id == transaction_entry.get('instrument')
-            ).to_hash()
+            ).to_hash(0)
             details_metadata = {
                 'submitter_name': u'{0} {1}'.format(
                     submitter.get('first_name'),

--- a/metadata/rest/user_queries/query_base.py
+++ b/metadata/rest/user_queries/query_base.py
@@ -8,7 +8,7 @@ class QueryBase(object):
     @staticmethod
     def format_user_block(user_entry, option=None):
         """Construct a dictionary from a given user instance in the metadata stack."""
-        user_hash = user_entry.to_hash()
+        user_hash = user_entry.to_hash(0)
         proposal_xref = ProposalParticipant()
         where_exp = proposal_xref.where_clause({'person_id': user_entry.id})
         proposal_person_query = (
@@ -19,7 +19,7 @@ class QueryBase(object):
 
         clean_proposals = {}
         for prop in proposals:
-            info = prop.to_hash()
+            info = prop.to_hash(0)
             info.pop('abstract')
             prop_id = prop.id
             clean_proposals[prop_id] = info

--- a/metadata/rest/user_queries/user_search.py
+++ b/metadata/rest/user_queries/user_search.py
@@ -36,7 +36,6 @@ class UserSearch(QueryBase):
                     )
             where_clause &= (where_clause_part)
         objs = Users.select().where(where_clause).order_by(Users.last_name, Users.first_name)
-        # print objs.sql()
         if not objs:
             message = "No user entries were retrieved using the terms: '"
             message += '\' and \''.join(terms) + '\''

--- a/metadata/rest/userinfo.py
+++ b/metadata/rest/userinfo.py
@@ -26,9 +26,8 @@ def user_exists_decorator(func):
             )
     return func_wrapper
 
+
 # pylint: disable=too-few-public-methods
-
-
 class UserInfoAPI(object):
     """UserInfo API."""
 
@@ -36,8 +35,6 @@ class UserInfoAPI(object):
 
     def __init__(self):
         """Create local objects for subtree items."""
-        # self.by_user_id = ProposalUserSearch()
-        # self.search = ProposalTermSearch()
         self.search = UserSearch()
         self.by_id = UserLookup()
         self.by_user_id = UserLookup()


### PR DESCRIPTION
### Description

This removes the recursion depth for the rest methods that are used by status and reporting since they don't need that information.

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
