### PR TITLE
fix #106 add suspense date to objects

### DIFF
--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -6,7 +6,7 @@ from peewee import Expression, OP
 from metadata.rest.orm import CherryPyAPI
 from metadata.orm.transactions import Transactions
 from metadata.orm.utils import datetime_now_nomicrosecond, ExtendDateTimeField
-from metadata.orm.utils import unicode_type, ExtendDateField
+from metadata.orm.utils import unicode_type, ExtendDateField, date_converts
 
 
 # pylint: disable=too-many-instance-attributes
@@ -118,7 +118,15 @@ class Files(CherryPyAPI):
         self._set_only_if('transaction_id', obj, 'transaction', trans_func)
 
     def _where_date_clause(self, where_clause, kwargs):
-        for date in ['mtime', 'ctime', 'suspense_date']:
+        if 'suspense_date' in kwargs:
+            date_obj, date_oper = self._date_operator_compare(
+                'suspense_date',
+                kwargs,
+                dt_converts=date_converts
+            )
+            where_clause &= Expression(
+                Files.suspense_date, date_oper, date_obj)
+        for date in ['mtime', 'ctime']:
             if date in kwargs:
                 date_obj, date_oper = self._date_operator_compare(date, kwargs)
                 where_clause &= Expression(

--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -87,7 +87,8 @@ class Files(CherryPyAPI):
         obj['size'] = int(self.size)
         obj['hashsum'] = str(self.hashsum)
         obj['hashtype'] = str(self.hashtype)
-        obj['suspense_date'] = str(self.suspense_date.isoformat())
+        obj['suspense_date'] = str(self.suspense_date.isoformat(
+        )) if self.suspense_date is not None else None
         obj['encoding'] = str(self.encoding)
         return obj
 

--- a/metadata/orm/files.py
+++ b/metadata/orm/files.py
@@ -6,7 +6,7 @@ from peewee import Expression, OP
 from metadata.rest.orm import CherryPyAPI
 from metadata.orm.transactions import Transactions
 from metadata.orm.utils import datetime_now_nomicrosecond, ExtendDateTimeField
-from metadata.orm.utils import unicode_type
+from metadata.orm.utils import unicode_type, ExtendDateField
 
 
 # pylint: disable=too-many-instance-attributes
@@ -18,29 +18,31 @@ class Files(CherryPyAPI):
     it came from.
 
     Attributes:
-        +-------------+-------------------------------------------+
-        | Name        | Description                               |
-        +=============+===========================================+
-        | name        | Name of the file                          |
-        +-------------+-------------------------------------------+
-        | subdir      | Subdirectory the file is in               |
-        +-------------+-------------------------------------------+
-        | ctime       | Creation time for the file                |
-        +-------------+-------------------------------------------+
-        | mtime       | User modified time for the file           |
-        +-------------+-------------------------------------------+
-        | hashsum     | Hash sum string                           |
-        +-------------+-------------------------------------------+
-        | hashtype    | Hash sum type string                      |
-        +-------------+-------------------------------------------+
-        | size        | Size of the file in bytes                 |
-        +-------------+-------------------------------------------+
-        | transaction | Link to the transaction model             |
-        +-------------+-------------------------------------------+
-        | mimetype    | mimetype of the file, if any              |
-        +-------------+-------------------------------------------+
-        | encoding    | encoding in the file name or subdir field |
-        +-------------+-------------------------------------------+
+        +---------------+-------------------------------------------+
+        | Name          | Description                               |
+        +===============+===========================================+
+        | name          | Name of the file                          |
+        +---------------+-------------------------------------------+
+        | subdir        | Subdirectory the file is in               |
+        +---------------+-------------------------------------------+
+        | ctime         | Creation time for the file                |
+        +---------------+-------------------------------------------+
+        | mtime         | User modified time for the file           |
+        +---------------+-------------------------------------------+
+        | hashsum       | Hash sum string                           |
+        +---------------+-------------------------------------------+
+        | hashtype      | Hash sum type string                      |
+        +---------------+-------------------------------------------+
+        | size          | Size of the file in bytes                 |
+        +---------------+-------------------------------------------+
+        | transaction   | Link to the transaction model             |
+        +---------------+-------------------------------------------+
+        | mimetype      | mimetype of the file, if any              |
+        +---------------+-------------------------------------------+
+        | suspense_date | date the proposal is made available       |
+        +---------------+-------------------------------------------+
+        | encoding      | encoding in the file name or subdir field |
+        +---------------+-------------------------------------------+
     """
 
     name = CharField(default='', index=True)
@@ -54,6 +56,7 @@ class Files(CherryPyAPI):
         Transactions, related_name='files', index=True)
     mimetype = CharField(default='')
     encoding = CharField(default='UTF8')
+    suspense_date = ExtendDateField(null=True, index=True)
 
     @staticmethod
     def elastic_mapping_builder(obj):
@@ -67,6 +70,7 @@ class Files(CherryPyAPI):
             obj['encoding'] = {'type': 'text', 'fields': {
                 'keyword': {'type': 'keyword', 'ignore_above': 256}}}
         obj['hashsum'] = obj['hashtype'] = {'type': 'text'}
+        obj['suspense_date'] = {'type': 'date', 'format': 'yyyy-mm-dd'}
 
     def to_hash(self, **flags):
         """Convert the object to a hash."""
@@ -83,6 +87,7 @@ class Files(CherryPyAPI):
         obj['size'] = int(self.size)
         obj['hashsum'] = str(self.hashsum)
         obj['hashtype'] = str(self.hashtype)
+        obj['suspense_date'] = str(self.suspense_date.isoformat())
         obj['encoding'] = str(self.encoding)
         return obj
 
@@ -105,6 +110,7 @@ class Files(CherryPyAPI):
         self._set_only_if('size', obj, 'size', lambda: int(obj['size']))
         self._set_only_if('encoding', obj, 'encoding',
                           lambda: str(obj['encoding']))
+        self._set_date_part('suspense_date', obj)
 
         def trans_func():
             """Return the transaction for the obj id."""
@@ -112,7 +118,7 @@ class Files(CherryPyAPI):
         self._set_only_if('transaction_id', obj, 'transaction', trans_func)
 
     def _where_date_clause(self, where_clause, kwargs):
-        for date in ['mtime', 'ctime']:
+        for date in ['mtime', 'ctime', 'suspense_date']:
             if date in kwargs:
                 date_obj, date_oper = self._date_operator_compare(date, kwargs)
                 where_clause &= Expression(

--- a/metadata/orm/proposals.py
+++ b/metadata/orm/proposals.py
@@ -101,7 +101,7 @@ class Proposals(CherryPyAPI):
         _set_only_if('closed_date', self.closed_date is None,
                      None, lambda: self.closed_date.isoformat())
         _set_only_if('suspense_date', self.suspense_date is None,
-                     None, lambda: self.supense_date.isoformat())
+                     None, lambda: self.suspense_date.isoformat())
         # pylint: enable=unnecessary-lambda
         obj['encoding'] = str(self.encoding)
         return obj

--- a/metadata/orm/proposals.py
+++ b/metadata/orm/proposals.py
@@ -35,6 +35,8 @@ class Proposals(CherryPyAPI):
         +-------------------+-------------------------------------+
         | closed_date       | date the proposal was terminated    |
         +-------------------+-------------------------------------+
+        | suspense_date     | date the proposal is made available |
+        +-------------------+-------------------------------------+
         | encoding          | encoding of the other text attrs    |
         +-------------------+-------------------------------------+
     """
@@ -51,6 +53,7 @@ class Proposals(CherryPyAPI):
     actual_start_date = ExtendDateField(null=True, index=True)
     actual_end_date = ExtendDateField(null=True, index=True)
     closed_date = ExtendDateField(null=True, index=True)
+    suspense_date = ExtendDateField(null=True, index=True)
     encoding = CharField(default='UTF8')
 
     @staticmethod
@@ -67,7 +70,7 @@ class Proposals(CherryPyAPI):
 
         obj['actual_start_date'] = obj['accepted_date'] = \
             obj['actual_end_date'] = obj['closed_date'] = \
-            {'type': 'date', 'format': 'yyyy-mm-dd'}
+            obj['suspense_date'] = {'type': 'date', 'format': 'yyyy-mm-dd'}
 
     def to_hash(self, **flags):
         """Convert the object to a hash."""
@@ -97,6 +100,8 @@ class Proposals(CherryPyAPI):
                      None, lambda: self.actual_end_date.isoformat())
         _set_only_if('closed_date', self.closed_date is None,
                      None, lambda: self.closed_date.isoformat())
+        _set_only_if('suspense_date', self.suspense_date is None,
+                     None, lambda: self.supense_date.isoformat())
         # pylint: enable=unnecessary-lambda
         obj['encoding'] = str(self.encoding)
         return obj
@@ -122,9 +127,16 @@ class Proposals(CherryPyAPI):
         self._set_date_part('actual_start_date', obj)
         self._set_date_part('actual_end_date', obj)
         self._set_date_part('closed_date', obj)
+        self._set_date_part('suspense_date', obj)
 
     def _where_date_clause(self, where_clause, kwargs):
-        date_keys = ['accepted_date', 'actual_start_date', 'actual_end_date']
+        date_keys = [
+            'accepted_date',
+            'actual_start_date',
+            'actual_end_date',
+            'closed_date',
+            'suspense_date'
+        ]
         for date_key in date_keys:
             if date_key in kwargs:
                 date_obj, date_oper = self._date_operator_compare(

--- a/metadata/orm/test/test_files.py
+++ b/metadata/orm/test/test_files.py
@@ -20,6 +20,7 @@ SAMPLE_FILE_HASH = {
     'hashsum': 'd8ff327b2f643130b431ae7c1f1b1e191bc419af',
     'size': 1234,
     'transaction_id': SAMPLE_TRANSACTION_HASH['_id'],
+    'suspense_date': datetime.utcnow().date().isoformat(),
     'encoding': 'UTF8'
 }
 
@@ -34,6 +35,7 @@ SAMPLE_UNICODE_FILE_HASH = {
     'hashsum': 'd8ff327b2f643130b431ae7c1f1b1e191bc419af',
     'size': 1234,
     'transaction_id': SAMPLE_TRANSACTION_HASH['_id'],
+    'suspense_date': datetime.utcnow().date().isoformat(),
     'encoding': 'UTF8'
 }
 

--- a/metadata/orm/test/test_proposals.py
+++ b/metadata/orm/test/test_proposals.py
@@ -21,7 +21,8 @@ This is my proposal that's really cool and you should accept it. ;)
     'accepted_date': datetime.utcnow().date().isoformat(),
     'actual_start_date': datetime.utcnow().date().isoformat(),
     'actual_end_date': datetime.utcnow().date().isoformat(),
-    'closed_date': datetime.utcnow().date().isoformat()
+    'closed_date': datetime.utcnow().date().isoformat(),
+    'suspense_date': datetime.utcnow().date().isoformat()
 }
 
 SAMPLE_UNICODE_PROPOSAL_HASH = {
@@ -38,7 +39,8 @@ This is my proposal that's réally cool and you should accept it. ;)
     'accepted_date': datetime.utcnow().date().isoformat(),
     'actual_start_date': datetime.utcnow().date().isoformat(),
     'actual_end_date': datetime.utcnow().date().isoformat(),
-    'closed_date': datetime.utcnow().date().isoformat()
+    'closed_date': datetime.utcnow().date().isoformat(),
+    'suspense_date': datetime.utcnow().date().isoformat()
 }
 
 

--- a/metadata/orm/test/test_transactions.py
+++ b/metadata/orm/test/test_transactions.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Test the keys ORM object."""
 from json import dumps
+from datetime import datetime
 from metadata.orm.test.base import TestBase
 from metadata.orm.transactions import Transactions
 from metadata.orm.test.test_users import SAMPLE_USER_HASH as SAMPLE_SUBMITTER_HASH
@@ -16,7 +17,8 @@ SAMPLE_TRANSACTION_HASH = {
     '_id': 127,
     'submitter': SAMPLE_SUBMITTER_HASH['_id'],
     'proposal': SAMPLE_PROPOSAL_HASH['_id'],
-    'instrument': SAMPLE_INSTRUMENT_HASH['_id']
+    'instrument': SAMPLE_INSTRUMENT_HASH['_id'],
+    'suspense_date': datetime.utcnow().date().isoformat()
 }
 
 

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -6,7 +6,7 @@ from metadata.rest.orm import CherryPyAPI
 from metadata.orm.users import Users
 from metadata.orm.proposals import Proposals
 from metadata.orm.instruments import Instruments
-from metadata.orm.utils import unicode_type, ExtendDateField
+from metadata.orm.utils import unicode_type, ExtendDateField, date_converts
 
 
 class Transactions(CherryPyAPI):
@@ -69,7 +69,8 @@ class Transactions(CherryPyAPI):
     def _where_date_clause(self, where_clause, kwargs):
         for date in ['suspense_date']:
             if date in kwargs:
-                date_obj, date_oper = self._date_operator_compare(date, kwargs)
+                date_obj, date_oper = self._date_operator_compare(
+                    date, kwargs, dt_converts=date_converts)
                 where_clause &= Expression(
                     getattr(Transactions, date), date_oper, date_obj)
         return where_clause

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -49,7 +49,8 @@ class Transactions(CherryPyAPI):
         obj['submitter'] = int(self._data['submitter'])
         obj['instrument'] = int(self._data['instrument'])
         obj['proposal'] = unicode_type(self._data['proposal'])
-        obj['suspense_date'] = str(self.suspense_date.isoformat())
+        obj['suspense_date'] = str(self.suspense_date.isoformat(
+        )) if self.suspense_date is not None else None
         return obj
 
     def from_hash(self, obj):

--- a/metadata/orm/transactions.py
+++ b/metadata/orm/transactions.py
@@ -6,7 +6,7 @@ from metadata.rest.orm import CherryPyAPI
 from metadata.orm.users import Users
 from metadata.orm.proposals import Proposals
 from metadata.orm.instruments import Instruments
-from metadata.orm.utils import unicode_type
+from metadata.orm.utils import unicode_type, ExtendDateField
 
 
 class Transactions(CherryPyAPI):
@@ -23,11 +23,14 @@ class Transactions(CherryPyAPI):
         +-------------------+--------------------------------------+
         | proposal          | Proposal the transaction is for      |
         +-------------------+--------------------------------------+
+        | suspense_date     | date the transaction is available    |
+        +-------------------+--------------------------------------+
     """
 
     submitter = ForeignKeyField(Users, related_name='transactions')
     instrument = ForeignKeyField(Instruments, related_name='transactions')
     proposal = ForeignKeyField(Proposals, related_name='transactions')
+    suspense_date = ExtendDateField(null=True, index=True)
 
     @staticmethod
     def elastic_mapping_builder(obj):
@@ -37,6 +40,7 @@ class Transactions(CherryPyAPI):
         obj['instrument'] = {'type': 'integer'}
         obj['proposal'] = {'type': 'text', 'fields': {
             'keyword': {'type': 'keyword', 'ignore_above': 256}}}
+        obj['suspense_date'] = {'type': 'date', 'format': 'yyyy-mm-dd'}
 
     def to_hash(self, **flags):
         """Convert the object to a hash."""
@@ -45,35 +49,44 @@ class Transactions(CherryPyAPI):
         obj['submitter'] = int(self._data['submitter'])
         obj['instrument'] = int(self._data['instrument'])
         obj['proposal'] = unicode_type(self._data['proposal'])
+        obj['suspense_date'] = str(self.suspense_date.isoformat())
         return obj
 
     def from_hash(self, obj):
         """Convert the hash into the object."""
         super(Transactions, self).from_hash(obj)
-        if '_id' in obj:
-            # pylint: disable=invalid-name
-            self.id = int(obj['_id'])
-            # pylint: enable=invalid-name
-        if 'submitter' in obj:
-            self.submitter = Users.get(Users.id == obj['submitter'])
-        if 'instrument' in obj:
-            self.instrument = Instruments.get(
-                Instruments.id == obj['instrument'])
-        if 'proposal' in obj:
-            self.proposal = Proposals.get(Proposals.id == obj['proposal'])
+        self._set_only_if('_id', obj, 'id', lambda: int(obj['_id']))
+        attr_cls_map = [
+            ('submitter', Users),
+            ('instrument', Instruments),
+            ('proposal', Proposals)
+        ]
+        for key, obj_cls in attr_cls_map:
+            self._set_only_if(
+                key, obj, key, lambda o=obj_cls, k=key: o.get(o.id == obj[k]))
+        self._set_date_part('suspense_date', obj)
+
+    def _where_date_clause(self, where_clause, kwargs):
+        for date in ['suspense_date']:
+            if date in kwargs:
+                date_obj, date_oper = self._date_operator_compare(date, kwargs)
+                where_clause &= Expression(
+                    getattr(Transactions, date), date_oper, date_obj)
+        return where_clause
 
     def where_clause(self, kwargs):
         """Where clause for the various elements."""
         where_clause = super(Transactions, self).where_clause(kwargs)
         if '_id' in kwargs:
             where_clause &= Expression(Transactions.id, OP.EQ, kwargs['_id'])
-        if 'submitter' in kwargs:
-            user = int(kwargs['submitter'])
-            where_clause &= Expression(Transactions.submitter, OP.EQ, user)
-        if 'instrument' in kwargs:
-            inst = int(kwargs['instrument'])
-            where_clause &= Expression(Transactions.instrument, OP.EQ, inst)
-        if 'proposal' in kwargs:
-            prop = kwargs['proposal']
-            where_clause &= Expression(Transactions.proposal, OP.EQ, prop)
+        where_clause = self._where_attr_clause(
+            where_clause,
+            kwargs,
+            [
+                'submitter',
+                'instrument',
+                'proposal'
+            ]
+        )
+        where_clause = self._where_date_clause(where_clause, kwargs)
         return where_clause

--- a/test_files/files.json
+++ b/test_files/files.json
@@ -7,6 +7,7 @@
     "name": "foo.txt",
     "size": 123,
     "subdir": "a/b",
+    "suspense_date": "Sat Nov 12 2016",
     "transaction_id": 67
   },
   {
@@ -17,6 +18,7 @@
     "name": "bar.txt",
     "size": 3221225472,
     "subdir": "a/b",
+    "suspense_date": "Sat Nov 12 2016",
     "transaction_id": 67
   }
 ]

--- a/test_files/proposals.json
+++ b/test_files/proposals.json
@@ -8,6 +8,7 @@
     "closed_date": null,
     "science_theme": "g\u00e9neral",
     "submitted_date": "Fri Sep 13 08:15:26 2013",
+    "suspense_date": "Sat Nov 12 2016",
     "title": "Pacifica D\u00e9velopment (active no close)"
   },
   {
@@ -19,6 +20,7 @@
     "closed_date": null,
     "science_theme": "g\u00e9neral",
     "submitted_date": "Fri Sep 13 08:15:26 2013",
+    "suspense_date": "Sat Nov 12 2016",
     "title": "Pacifica D\u00e9velopment (no close or end)"
   },
   {
@@ -30,6 +32,7 @@
     "closed_date": "Mon Sep 29 2014",
     "science_theme": "g\u00e9neral",
     "submitted_date": "Fri Sep 13 08:15:26 2013",
+    "suspense_date": "Sat Nov 12 2016",
     "title": "Pacifica D\u00e9velopment (expired closed and end)"
   },
   {
@@ -41,6 +44,7 @@
     "closed_date": "Mon Sep 29 2014",
     "science_theme": "g\u00e9neral",
     "submitted_date": "Fri Sep 13 08:15:26 2013",
+    "suspense_date": "Sat Nov 12 2016",
     "title": "Pacifica D\u00e9velopment (expired closed no end)"
   },
   {
@@ -52,6 +56,7 @@
     "closed_date": null,
     "science_theme": "g\u00e9neral",
     "submitted_date": "Fri Sep 13 08:15:26 2013",
+    "suspense_date": "Sat Nov 12 2016",
     "title": "Pacifica D\u00e9velopment (pre-active)"
   }
 ]

--- a/test_files/transactions.json
+++ b/test_files/transactions.json
@@ -4,20 +4,23 @@
     "created": "Mon Jul 15 00:00:00 2017",
     "instrument": 54,
     "proposal": "1234a",
-    "submitter": 10
+    "submitter": 10,
+    "suspense_date": "Sat Nov 12 2016"
   },
   {
     "_id": 68,
     "created": "Mon Jul 10 00:00:00 2017",
     "instrument": 54,
     "proposal": "1237",
-    "submitter": 10
+    "submitter": 10,
+    "suspense_date": "Sat Nov 12 2016"
   },
   {
     "_id": 69,
     "created": "Mon Jul 1 00:00:00 2017",
     "instrument": 54,
     "proposal": "1236\u00e9",
-    "submitter": 10
+    "submitter": 10,
+    "suspense_date": "Sat Nov 12 2016"
   }
 ]


### PR DESCRIPTION
### Description

This adds suspense date to the respective objects Proposal, Transactions and Files.

### Issues Resolved

#106 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
