### PR TITLE
add proposal has data endpoint

### DIFF
--- a/metadata/rest/proposal_queries/proposal_has_data.py
+++ b/metadata/rest/proposal_queries/proposal_has_data.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""CherryPy Status Metadata object class."""
+import cherrypy
+from cherrypy import tools
+from peewee import fn
+from metadata.orm import Transactions
+from metadata.rest.proposal_queries.query_base import QueryBase
+from metadata.orm.base import db_connection_decorator
+
+
+class ProposalHasData(QueryBase):
+    """Does the proposal have data for instruments."""
+
+    exposed = True
+
+    # CherryPy requires these named methods
+    # Add HEAD (basically Get without returning body
+    # pylint: disable=invalid-name
+    @staticmethod
+    @tools.json_out()
+    @tools.json_in()
+    @db_connection_decorator
+    def POST():
+        """CherryPy GET method."""
+        return {
+            proposal_id: [
+                {
+                    'instrument': tx.instrument,
+                    'start_time': tx.start_time.isoformat(),
+                    'end_time': tx.end_time.isoformat(),
+                    'num_results': tx.count
+                } for tx in Transactions.select(
+                    Transactions.instrument,
+                    fn.Max(Transactions.created).alias('start_time'),
+                    fn.Min(Transactions.created).alias('end_time'),
+                    fn.count(Transactions.id).alias('count')
+                ).where(
+                    Transactions.proposal == proposal_id
+                ).order_by(
+                    Transactions.created
+                ).limit(10)
+            ] for proposal_id in cherrypy.request.body.json()
+        }

--- a/metadata/rest/proposalinfo.py
+++ b/metadata/rest/proposalinfo.py
@@ -4,6 +4,7 @@
 from metadata.rest.proposal_queries.proposal_lookup import ProposalLookup
 from metadata.rest.proposal_queries.proposal_term_search import ProposalTermSearch
 from metadata.rest.proposal_queries.proposal_user_search import ProposalUserSearch
+from metadata.rest.proposal_queries.proposal_has_data import ProposalHasData
 
 
 # pylint: disable=too-few-public-methods
@@ -17,3 +18,4 @@ class ProposalInfoAPI(object):
         self.by_user_id = ProposalUserSearch()
         self.search = ProposalTermSearch()
         self.by_proposal_id = ProposalLookup()
+        self.has_data = ProposalHasData()

--- a/metadata/rest/test/test_proposalinfo.py
+++ b/metadata/rest/test/test_proposalinfo.py
@@ -90,3 +90,11 @@ class TestProposalInfoAPI(CPCommonTest):
             '{0}/proposalinfo/search/{1}'.format(self.url, search_terms))
         self.assertEqual(req.status_code, 404)
         self.assertTrue('No Valid Proposals' in req.text)
+
+    def test_has_data(self):
+        """Test the proposal has data definition."""
+        req = requests.post(
+            '{0}/proposalinfo/has_data'.format(self.url),
+            json=['1234']
+        )
+        self.assertEqual(req.status_code, 200)


### PR DESCRIPTION
### Description

Fix #120 add the proposal has data endpoint. This endpoint will return whether proposals have data or not. However, is not a full listing of all data for the proposal only a short yes it does.

### Issues Resolved

#120 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
