### PR TITLE
Fix #119 by adding a delete argument to render

### DIFF
--- a/metadata/admin_cmd.py
+++ b/metadata/admin_cmd.py
@@ -14,14 +14,17 @@ def render_obj(args):
     """Render an object based on args."""
     try_db_connect()
     test_obj = args.object()
+    test_obj = args.object.get(
+        test_obj.where_clause(args.where_clause)
+    )
     print(
         dumps(
-            args.object.get(
-                test_obj.where_clause(args.where_clause)
-            ).to_hash(recursion_depth=args.recursion),
+            test_obj.to_hash(recursion_depth=args.recursion),
             indent=4
         )
     )
+    if args.delete:
+        test_obj.delete_instance()
 
 
 def create_obj(args):
@@ -154,6 +157,14 @@ def render_options(render_parser):
         dest='recursion',
         type=int,
         help='recursive level to go',
+        required=False
+    )
+    render_parser.add_argument(
+        '--delete',
+        default='store_false',
+        action='store_true',
+        dest='delete',
+        help='delete the object',
         required=False
     )
     render_parser.set_defaults(func=render_obj)

--- a/metadata/test/test_admin.py
+++ b/metadata/test/test_admin.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 from datetime import timedelta
 from unittest import TestCase
 from mock import patch
-from peewee import SqliteDatabase
+from peewee import SqliteDatabase, DoesNotExist
 import metadata.orm as metaorm
 from metadata.admin_cmd import main, essync, escreate, render_obj, create_obj
 from metadata.admin_cmd import objstr_to_ormobj, objstr_to_whereclause, objstr_to_timedelta
@@ -70,10 +70,17 @@ class TestAdminTool(TestCase):
         setattr(args, 'object', metaorm.Keys)
         setattr(args, 'where_clause', {'key': 'test_key'})
         setattr(args, 'recursion', 1)
+        setattr(args, 'delete', True)
         test_obj = metaorm.Keys()
         test_obj.key = 'test_key'
         test_obj.save()
         render_obj(args)
+        hit_exception = False
+        try:
+            metaorm.Keys().get()
+        except DoesNotExist:
+            hit_exception = True
+        self.assertTrue(hit_exception)
         self.assertTrue(test_patch.called)
 
     @patch('metadata.orm.try_db_connect')


### PR DESCRIPTION
### Description

This adds the delete argument to render, it will allow admins to
really, really delete an entry in the database.

### Issues Resolved

#119 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
