### PR TITLE
Issue 133 doidatasets primary key

### DIFF
--- a/metadata/orm/base.py
+++ b/metadata/orm/base.py
@@ -168,11 +168,13 @@ class PacificaModel(Model):
         fk_obj_list = obj_ref.cls_foreignkey_rel_mods()
         valid_fk_obj_list = list(
             set(fk_obj_list) - set([self.__class__]))
+        # pylint: disable=protected-access
         if len(valid_fk_obj_list) == 1:
             fk_item_name = fk_obj_list[valid_fk_obj_list.pop()]
         else:
             fk_item_name = obj_ref.__class__._meta.__dict__[
                 'primary_key'].__dict__['column_name']
+        # pylint: enable=protected-access
         return fk_item_name, fk_obj_list
 
     def from_hash(self, obj):

--- a/metadata/orm/base.py
+++ b/metadata/orm/base.py
@@ -154,7 +154,6 @@ class PacificaModel(Model):
     @staticmethod
     def get_append_item(obj_ref, fk_item_name, fk_obj_list):
         """Generate the proper item to append to the newly built object."""
-        # pylint: disable=protected-access
         if 'key' in fk_obj_list.values() and 'value' in fk_obj_list.values():
             append_item = {
                 'key_id': obj_ref.__data__['key'],
@@ -172,7 +171,7 @@ class PacificaModel(Model):
         if len(valid_fk_obj_list) == 1:
             fk_item_name = fk_obj_list[valid_fk_obj_list.pop()]
         else:
-            fk_item_name = 'id'
+            fk_item_name = obj_ref.__class__._meta.__dict__['primary_key'].__dict__['column_name']
         return fk_item_name, fk_obj_list
 
     def from_hash(self, obj):

--- a/metadata/orm/base.py
+++ b/metadata/orm/base.py
@@ -171,7 +171,8 @@ class PacificaModel(Model):
         if len(valid_fk_obj_list) == 1:
             fk_item_name = fk_obj_list[valid_fk_obj_list.pop()]
         else:
-            fk_item_name = obj_ref.__class__._meta.__dict__['primary_key'].__dict__['column_name']
+            fk_item_name = obj_ref.__class__._meta.__dict__[
+                'primary_key'].__dict__['column_name']
         return fk_item_name, fk_obj_list
 
     def from_hash(self, obj):

--- a/metadata/orm/doi_release.py
+++ b/metadata/orm/doi_release.py
@@ -24,7 +24,7 @@ class DOIRelease(CherryPyAPI):
     """
 
     doi = ForeignKeyField(
-        DOIDataSets, related_name='doi_releases', to_field='doi')
+        DOIDataSets, related_name='doi_entries', to_field='doi')
     release = ForeignKeyField(TransactionRelease, related_name='doi_releases')
 
     # pylint: disable=too-few-public-methods

--- a/metadata/orm/doidatasets.py
+++ b/metadata/orm/doidatasets.py
@@ -23,7 +23,7 @@ class DOIDataSets(CherryPyAPI):
         +-------------------+-------------------------------------+
     """
 
-    doi = CharField(unique=True)
+    doi = CharField(primary_key=True)
     name = CharField(default='')
     encoding = CharField(default='UTF8')
     creator = ForeignKeyField(Users, related_name='dois_created')

--- a/metadata/orm/test/base.py
+++ b/metadata/orm/test/base.py
@@ -68,8 +68,10 @@ class TestBase(TestCase):
         check all keys in the new hash from the obj_hash passed
         """
         obj = self.base_create_obj(self.obj_cls, obj_hash)
+        # pylint: disable=no-member
         new_obj = self.obj_cls.get(
             self.obj_id == getattr(obj, self.obj_id.column_name))
+        # pylint: enable=no-member
         chk_obj_hash = new_obj.to_hash()
         self.assertTrue('_id' in chk_obj_hash)
         for key in obj_hash.keys():
@@ -91,8 +93,10 @@ class TestBase(TestCase):
         obj = self.obj_cls()
         obj.from_hash(loads(json_str))
         obj.save(force_insert=True)
+        # pylint: disable=no-member
         new_obj = self.obj_cls.get(
             self.obj_id == getattr(obj, self.obj_id.column_name))
+        # pylint: enable=no-member
         chk_obj_json = dumps(new_obj.to_hash())
         self.assertEqual(type(chk_obj_json), str)
 

--- a/metadata/orm/test/test_doidatasets.py
+++ b/metadata/orm/test/test_doidatasets.py
@@ -29,7 +29,7 @@ class TestDOIDataSets(TestBase):
     """Test the Keywords ORM object."""
 
     obj_cls = DOIDataSets
-    obj_id = DOIDataSets.id
+    obj_id = DOIDataSets.doi
 
     @classmethod
     def base_create_dep_objs(cls):

--- a/metadata/orm/test/test_doidatasets.py
+++ b/metadata/orm/test/test_doidatasets.py
@@ -9,7 +9,6 @@ from metadata.orm.test.test_users import TestUsers
 from metadata.orm.users import Users
 
 SAMPLE_DOIDATASET_HASH = {
-    '_id': 142,
     'doi': 'halitosis',
     'name': 'halitosis',
     'encoding': 'UTF8',
@@ -19,7 +18,6 @@ SAMPLE_DOIDATASET_HASH = {
 # yes a DOI can be unicode....
 # https://www.doi.org/doi_handbook/2_Numbering.html#2.2.1
 SAMPLE_UNICODE_DOIDATASET_HASH = {
-    '_id': 143,
     'doi': u'blargééééé',
     'name': u'blargééééé',
     'encoding': 'UTF8',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ mock
 nose
 peewee>2
 pep257
-psycopg2
+psycopg2-binary
 pylint
 pytest
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cherrypy
 elasticsearch
 peewee>2
-psycopg2
+psycopg2-binary
 python-dateutil
 requests
 six


### PR DESCRIPTION
### Description

switches out the primary key in the DOIDataSets object to use the full DOI reference string instead of a generated integer key

### Issues Resolved

#133 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
