### PR TITLE
Fix #146 Add event emittion to a notification service

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
   PGSQL_PATH: C:\Program Files\PostgreSQL\9.6
   POSTGRES_ENV_POSTGRES_USER: postgres
   POSTGRES_ENV_POSTGRES_PASSWORD: Password12!
+  NOTIFICATIONS_URL: http://127.0.0.1:8080
 
   matrix:
     - PYTHON: C:\Python27-x64
@@ -40,6 +41,7 @@ install:
     Expand-Archive "elasticsearch.zip" -DestinationPath "C:\elasticsearch";
     Start-Process C:\elasticsearch\elasticsearch-5.6.8\bin\elasticsearch;
     & $env:PYTHON\python.exe -m pip install -r requirements-dev.txt;
+    Start-Process "${env:PYTHON}\Scripts\python.exe" -ArgumentList "test_files\cherrypy_catch.py";
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
     Expand-Archive "elasticsearch.zip" -DestinationPath "C:\elasticsearch";
     Start-Process C:\elasticsearch\elasticsearch-5.6.8\bin\elasticsearch;
     & $env:PYTHON\python.exe -m pip install -r requirements-dev.txt;
-    Start-Process "${env:PYTHON}\Scripts\python.exe" -ArgumentList "test_files\cherrypy_catch.py";
+    Start-Process "${env:PYTHON}\python.exe" -ArgumentList "test_files\cherrypy_catch.py";
 
 build: off
 

--- a/metadata/rest/test/test_ingest.py
+++ b/metadata/rest/test/test_ingest.py
@@ -98,7 +98,7 @@ class TestIngestAPI(CPCommonTest):
 
         putdata[0]['value'] += 1
         putdata[7]['_id'] += 10
-        putdata[9]['value'] += 10
+        putdata[9]['_id'] += 10
         # notifications url shouldn't be listening
         # however accepting the data should be okay
         os.environ['NOTIFICATIONS_URL'] = 'http://127.0.0.1:8070'

--- a/metadata/rest/test/test_ingest.py
+++ b/metadata/rest/test/test_ingest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Test the ORM interface IngestAPI."""
+import os
 from json import dumps, loads
 import requests
 from metadata.rest.test import CPCommonTest
@@ -95,6 +96,13 @@ class TestIngestAPI(CPCommonTest):
         self.assertEqual(req.text, '{"status": "success"}')
         self.assertEqual(req.status_code, 200)
 
+        # notifications url shouldn't be listening
+        # however accepting the data should be okay
+        os.environ['NOTIFICATIONS_URL'] = 'http://127.0.0.1:8070'
+        req = requests.put(
+            '{0}/ingest'.format(self.url), data=dumps(putdata), headers={'content-type': 'application/json'})
+        self.assertEqual(req.text, '{"status": "success"}')
+        self.assertEqual(req.status_code, 200)
         # generate bad file metadata
         putdata[0]['value'] += 1
         putdata[7]['hashtype'] = ''

--- a/metadata/rest/test/test_ingest.py
+++ b/metadata/rest/test/test_ingest.py
@@ -98,6 +98,7 @@ class TestIngestAPI(CPCommonTest):
 
         putdata[0]['value'] += 1
         putdata[7]['_id'] += 10
+        putdata[8]['file_id'] += 10
         putdata[9]['_id'] += 10
         # notifications url shouldn't be listening
         # however accepting the data should be okay

--- a/metadata/rest/test/test_ingest.py
+++ b/metadata/rest/test/test_ingest.py
@@ -96,6 +96,9 @@ class TestIngestAPI(CPCommonTest):
         self.assertEqual(req.text, '{"status": "success"}')
         self.assertEqual(req.status_code, 200)
 
+        putdata[0]['value'] += 1
+        putdata[7]['_id'] += 10
+        putdata[9]['value'] += 10
         # notifications url shouldn't be listening
         # however accepting the data should be okay
         os.environ['NOTIFICATIONS_URL'] = 'http://127.0.0.1:8070'
@@ -103,6 +106,7 @@ class TestIngestAPI(CPCommonTest):
             '{0}/ingest'.format(self.url), data=dumps(putdata), headers={'content-type': 'application/json'})
         self.assertEqual(req.text, '{"status": "success"}')
         self.assertEqual(req.status_code, 200)
+
         # generate bad file metadata
         putdata[0]['value'] += 1
         putdata[7]['hashtype'] = ''

--- a/test_files/cherrypy_catch.py
+++ b/test_files/cherrypy_catch.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""This is an example CherryPy based event catch used in testing."""
+import cherrypy
+
+
+# pylint: disable=too-few-public-methods
+class Root(object):
+    """Example root cherrypy class, method dispatcher required."""
+
+    exposed = True
+
+    @cherrypy.tools.json_in()
+    @cherrypy.tools.json_out()
+    # pylint: disable=invalid-name
+    # pylint: disable=no-self-use
+    def POST(self):
+        """Accept the post data and return it."""
+        return cherrypy.request.json
+
+
+if __name__ == '__main__':
+    cherrypy.quickstart(Root(), '/', {
+        '/': {
+            'request.dispatch': cherrypy.dispatch.MethodDispatcher()
+        }
+    })

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 export POSTGRES_ENV_POSTGRES_USER=postgres
 export POSTGRES_ENV_POSTGRES_PASSWORD=
+export NOTIFICATIONS_URL=http://127.0.0.1:8080
+python test_files/cherrypy_catch.py &
 coverage run --include='metadata/*' -m pytest -v metadata/orm metadata/elastic metadata/test
 coverage run --include='metadata/*' -a -m pytest -v metadata/rest
 coverage run --include='metadata/*' -a MetadataServer.py --stop-after-a-moment


### PR DESCRIPTION
### Description
Add CloudEvents hook in the metadata server so it will emit events when data is ingested.
### Issues Resolved
#146 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
