### PR TITLE
make the between operator act a bit different

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 
 # GNU Dia
 *.dia~
+
+db.sqlite3
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 env:
 - RUN_LINTS=true
-- ES_VERSION=5.6.8
+- ES_VERSION=5.6.10
 
 cache: pip
 

--- a/metadata/orm/base.py
+++ b/metadata/orm/base.py
@@ -196,8 +196,8 @@ class PacificaModel(Model):
         else:
             date_oper = OP.EQ
         if date_oper == OP.BETWEEN:
-            date_obj_min = dt_converts(kwargs[date][0])
-            date_obj_max = dt_converts(kwargs[date][1])
+            date_obj_min = dt_converts(kwargs['{}_0'.format(date)])
+            date_obj_max = dt_converts(kwargs['{}_1'.format(date)])
             date_obj = NodeList((date_obj_min, SQL('AND'), date_obj_max))
         else:
             date_obj = dt_converts(kwargs[date])

--- a/metadata/orm/test/test_dbdates.py
+++ b/metadata/orm/test/test_dbdates.py
@@ -93,10 +93,8 @@ class TestDBDates(TestBase):
         objs = self.base_where_clause_search(third_obj, search_expr)
         self.assertEqual(len(objs), 2)
         search_expr = {
-            'created': [
-                date_check_min.replace(microsecond=0).isoformat(),
-                date_check_max.replace(microsecond=0).isoformat()
-            ],
+            'created_0': date_check_min.replace(microsecond=0).isoformat(),
+            'created_1': date_check_max.replace(microsecond=0).isoformat(),
             'created_operator': 'BETWEEN'
         }
         objs = self.base_where_clause_search(third_obj, search_expr)

--- a/metadata/orm/test/test_dbdates.py
+++ b/metadata/orm/test/test_dbdates.py
@@ -93,6 +93,7 @@ class TestDBDates(TestBase):
         objs = self.base_where_clause_search(third_obj, search_expr)
         self.assertEqual(len(objs), 2)
         search_expr = {
+            'created': '0',
             'created_0': date_check_min.replace(microsecond=0).isoformat(),
             'created_1': date_check_max.replace(microsecond=0).isoformat(),
             'created_operator': 'BETWEEN'


### PR DESCRIPTION
### Description
This adds a suffix of `_0` and `_1` to the dates when doing a between
comparison for date attributes. This allows the curl from the REST API
to work instead of throwing errors.

### Issues Resolved

Fix #151

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
