### PR TITLE
DOI Entries retrieval fix

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -143,8 +143,10 @@ class PacificaModel(Model):
         for obj_ref in getattr(self, attr):
             if not fk_obj_list:
                 fk_item_name, fk_obj_list = self._generate_fk_obj_list(obj_ref)
-            obj[attr].append(self.get_append_item(
-                obj_ref, fk_item_name, fk_obj_list))
+            append_item = self.get_append_item(
+                obj_ref, fk_item_name, fk_obj_list)
+            if append_item is not None:
+                obj[attr].append(append_item)
         return obj
 
     @staticmethod
@@ -156,7 +158,8 @@ class PacificaModel(Model):
                 'value_id': obj_ref.__data__['value']
             }
         else:
-            append_item = obj_ref.__data__[fk_item_name]
+            append_item = obj_ref.__data__[
+                fk_item_name] if fk_item_name in obj_ref.__data__ else None
         # pylint: enable=protected-access
         return append_item
 

--- a/pacifica/metadata/orm/doi_transaction.py
+++ b/pacifica/metadata/orm/doi_transaction.py
@@ -23,7 +23,7 @@ class DOITransaction(CherryPyAPI):
     """
 
     doi = ForeignKeyField(
-        DOIEntries, related_name='doi_entries', to_field='doi', column_name='doi', primary_key=True)
+        DOIEntries, related_name='transactions', to_field='doi', column_name='doi', primary_key=True)
     transaction = ForeignKeyField(
         TransactionRelease, to_field='transaction', related_name='doi_releases')
 


### PR DESCRIPTION
The issue comes up when the recursion functionality kicks in for the DOI Entries object and its associated metadata from DOI Info. We have fixes in place to deal with the special case of transaction key value fields and showing them for their parents, but DOIInfo is handled with out the key_id/value_id normalization step, so this solution doesn't work properly.

### Description

 I've basically disabled the recursive functionality for metadata members in cases where it doesn't work right. We don't really need the metadata info fields for DOI entries in nearly every case anyway.

### Issues Resolved

Fixes #161 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable