### PR TITLE
Revert the version attribute for all objects

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -17,7 +17,7 @@ and deleting these objects in from a web service layer.
 """
 import datetime
 from dateutil import parser
-from peewee import Model, Expression, OP, PrimaryKeyField, fn, CompositeKey, SQL, NodeList, BackrefAccessor, CharField
+from peewee import Model, Expression, OP, PrimaryKeyField, fn, CompositeKey, SQL, NodeList, BackrefAccessor
 from playhouse.db_url import connect
 from six import text_type
 from pacifica.metadata.config import get_config
@@ -57,8 +57,6 @@ class PacificaModel(Model):
         +-------------------+-------------------------------------+
         | deleted           | When was the object deleted         |
         +-------------------+-------------------------------------+
-        | version           | What version the object is          |
-        +-------------------+-------------------------------------+
     """
 
     # this is peewee specific need to disable this check
@@ -70,7 +68,6 @@ class PacificaModel(Model):
     updated = ExtendDateTimeField(
         default=datetime_now_nomicrosecond, index=True)
     deleted = ExtendDateTimeField(null=True, index=True)
-    version = CharField(default='v0.1.0')
 
     # pylint: disable=too-few-public-methods
     class Meta(object):
@@ -120,7 +117,6 @@ class PacificaModel(Model):
         recursion_depth = flags.get('recursion_depth', 0)
         recursion_limit = flags.get('recursion_limit', 1000)
         obj = {}
-        obj['version'] = self.version
         obj['created'] = self.created.isoformat()
         obj['updated'] = self.updated.isoformat()
         obj['deleted'] = self.deleted.isoformat(
@@ -181,7 +177,6 @@ class PacificaModel(Model):
         self._set_datetime_part('created', obj)
         self._set_datetime_part('updated', obj)
         self._set_datetime_part('deleted', obj)
-        self._set_only_if('version', obj, 'version', lambda: obj['version'])
 
     @staticmethod
     def _bool_translate(thing):


### PR DESCRIPTION
### Description

Revert the version attribute for all objects.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A Quick Fix

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
