### PR TITLE
Fixes weird edge case from datahub

### DIFF
--- a/pacifica/metadata/rest/transaction_queries/query_base.py
+++ b/pacifica/metadata/rest/transaction_queries/query_base.py
@@ -96,6 +96,10 @@ class QueryBase(object):
         transactions = QueryBase._get_transaction_entries(transaction_list)
         results = {}
         for trans in transactions:
+            if not trans.file_size_bytes:
+                trans.file_size_bytes = 0
+            if not trans.file_count:
+                trans.file_count = 0
             results[trans.id.id] = {
                 'total_file_size_bytes': int(trans.file_size_bytes),
                 'total_file_count': int(trans.file_count)

--- a/tests/rest/transactioninfo_test.py
+++ b/tests/rest/transactioninfo_test.py
@@ -157,13 +157,20 @@ class TestTransactionInfoAPI(CPCommonTest):
         self.assertEqual(data['67']['authorized_person']['first_name'], 'bob')
         req = requests.post(
             '{0}/transactioninfo/release_state'.format(self.url),
-            data='[{}, {}]'.format(str_transaction_id, 68),
+            data='[{}, {}]'.format(str_transaction_id, 67),
             headers={'content-type': 'application/json'}
         )
         data = loads(req.text)
         self.assertTrue('67' in data)
         self.assertEqual(data['67']['transaction'], 67)
         self.assertEqual(data['67']['authorized_person']['first_name'], 'bob')
+
+
+        req = requests.post(
+            '{0}/transactioninfo/release_state'.format(self.url),
+            data='[{}, {}]'.format(str_transaction_id, 69),
+            headers={'content-type': 'application/json'}
+        )
 
         str_transaction_id = 4239672
         req = requests.get(

--- a/tests/rest/transactioninfo_test.py
+++ b/tests/rest/transactioninfo_test.py
@@ -165,7 +165,6 @@ class TestTransactionInfoAPI(CPCommonTest):
         self.assertEqual(data['67']['transaction'], 67)
         self.assertEqual(data['67']['authorized_person']['first_name'], 'bob')
 
-
         req = requests.post(
             '{0}/transactioninfo/release_state'.format(self.url),
             data='[{}, {}]'.format(str_transaction_id, 69),

--- a/tests/rest/transactioninfo_test.py
+++ b/tests/rest/transactioninfo_test.py
@@ -157,7 +157,7 @@ class TestTransactionInfoAPI(CPCommonTest):
         self.assertEqual(data['67']['authorized_person']['first_name'], 'bob')
         req = requests.post(
             '{0}/transactioninfo/release_state'.format(self.url),
-            data='[{}, {}]'.format(str_transaction_id, 67),
+            data='[{}, {}]'.format(str_transaction_id, 68),
             headers={'content-type': 'application/json'}
         )
         data = loads(req.text)

--- a/tests/test_files/transaction_release.json
+++ b/tests/test_files/transaction_release.json
@@ -5,6 +5,6 @@
   },
   {
     "authorized_person": 11,
-    "transaction": 68
+    "transaction": 69
   }
 ]

--- a/tests/test_files/transaction_release.json
+++ b/tests/test_files/transaction_release.json
@@ -2,5 +2,9 @@
   {
     "authorized_person": 11,
     "transaction": 67
+  },
+  {
+    "authorized_person": 11,
+    "transaction": 68
   }
 ]


### PR DESCRIPTION
### Description

Issues when database would return None type for file sizes and get_release_states would barf

### Issues Resolved

#182

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
