### PR TITLE
Fix #157 add more expresive delete

### DIFF
--- a/pacifica/metadata/rest/orm.py
+++ b/pacifica/metadata/rest/orm.py
@@ -129,12 +129,21 @@ class CherryPyAPI(PacificaModel):
             clean_objs.append(db_obj)
         return clean_objs
 
+    def _force_delete(self, **kwargs):
+        """Force delete entries in the database."""
+        recursive = kwargs.pop('recursive', False)
+        for obj in self.select().where(self.where_clause(kwargs)):
+            obj.delete_instance(recursive)
+
     def _delete(self, **kwargs):
         """Internal delete object method."""
+        force = kwargs.pop('force', False)
+        if force:
+            return self._force_delete(**kwargs)
         update_hash = {
             'deleted': datetime_now_nomicrosecond().isoformat()
         }
-        self._update(update_hash, **kwargs)
+        return self._update(update_hash, **kwargs)
 
     # CherryPy requires these named methods
     # Add HEAD (basically Get without returning body


### PR DESCRIPTION
### Description

This adds more options to force delete from the API and from the
admin command line tools. New options will cascade delete the object
and related foreign keys in the database.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #195 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
