### PR TITLE
Add creating relationships by name and UUID

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -16,6 +16,7 @@ There are also CherryPy methods for creating, updating, getting
 and deleting these objects in from a web service layer.
 """
 import datetime
+import uuid
 from dateutil import parser
 from peewee import Model, Expression, OP, AutoField, fn, CompositeKey, SQL, NodeList, BackrefAccessor
 from six import text_type
@@ -76,6 +77,16 @@ class PacificaModel(Model):
     def _set_only_if(self, key, obj, dest_attr, func):
         if key in obj:
             setattr(self, dest_attr, func())
+
+    def _set_only_if_by_name(self, attr, obj, cls):
+        self._set_only_if(
+            '{}_name'.format(attr), obj, attr,
+            lambda: cls.get(cls.name == obj['{}_name'.format(attr)])
+        )
+        self._set_only_if(
+            attr, obj, attr,
+            lambda: cls.get(cls.uuid == uuid.UUID(obj[attr]))
+        )
 
     def _set_date_part(self, date_part, obj):
         self._set_only_if(date_part, obj, date_part,

--- a/pacifica/metadata/orm/institution_user.py
+++ b/pacifica/metadata/orm/institution_user.py
@@ -55,10 +55,7 @@ class InstitutionUser(CherryPyAPI):
         super(InstitutionUser, self).from_hash(obj)
         self._set_only_if('uuid', obj, 'uuid',
                           lambda: uuid.UUID(obj['uuid']))
-        self._set_only_if(
-            'relationship', obj, 'relationship',
-            lambda: Relationships.get(Relationships.uuid == uuid.UUID(obj['relationship']))
-        )
+        self._set_only_if_by_name('relationship', obj, Relationships)
         self._set_only_if(
             'user', obj, 'user',
             lambda: Users.get(Users.id == obj['user'])

--- a/pacifica/metadata/orm/instrument_data_source.py
+++ b/pacifica/metadata/orm/instrument_data_source.py
@@ -59,10 +59,8 @@ class InstrumentDataSource(CherryPyAPI):
             'instrument', obj, 'instrument',
             lambda: Instruments.get(Instruments.id == int(obj['instrument']))
         )
-        attr_rel_cls = [
-            ('data_source', DataSources),
-            ('relationship', Relationships)
-        ]
+        self._set_only_if_by_name('relationship', obj, Relationships)
+        attr_rel_cls = [('data_source', DataSources)]
         for attr, rel_cls in attr_rel_cls:
             self._set_only_if(
                 attr, obj, attr, lambda cls=rel_cls, o=obj, a=attr: cls.get(cls.uuid == uuid.UUID(o[a]))

--- a/pacifica/metadata/orm/instrument_user.py
+++ b/pacifica/metadata/orm/instrument_user.py
@@ -55,10 +55,7 @@ class InstrumentUser(CherryPyAPI):
         super(InstrumentUser, self).from_hash(obj)
         self._set_only_if('uuid', obj, 'uuid',
                           lambda: uuid.UUID(obj['uuid']))
-        self._set_only_if(
-            'relationship', obj, 'relationship',
-            lambda: Relationships.get(Relationships.uuid == uuid.UUID(obj['relationship']))
-        )
+        self._set_only_if_by_name('relationship', obj, Relationships)
         self._set_only_if(
             'instrument', obj, 'instrument',
             lambda: Instruments.get(Instruments.id == obj['instrument'])

--- a/pacifica/metadata/orm/project_instrument.py
+++ b/pacifica/metadata/orm/project_instrument.py
@@ -56,10 +56,7 @@ class ProjectInstrument(CherryPyAPI):
         super(ProjectInstrument, self).from_hash(obj)
         self._set_only_if('uuid', obj, 'uuid',
                           lambda: uuid.UUID(obj['uuid']))
-        self._set_only_if(
-            'relationship', obj, 'relationship',
-            lambda: Relationships.get(Relationships.uuid == uuid.UUID(obj['relationship']))
-        )
+        self._set_only_if_by_name('relationship', obj, Relationships)
         self._set_only_if(
             'instrument', obj, 'instrument',
             lambda: Instruments.get(Instruments.id == obj['instrument'])

--- a/pacifica/metadata/orm/project_user.py
+++ b/pacifica/metadata/orm/project_user.py
@@ -56,8 +56,7 @@ class ProjectUser(CherryPyAPI):
         super(ProjectUser, self).from_hash(obj)
         self._set_only_if('uuid', obj, 'uuid',
                           lambda: uuid.UUID(obj['uuid']))
-        self._set_only_if('relationship', obj, 'relationship',
-                          lambda: Relationships.get(Relationships.uuid == uuid.UUID(obj['relationship'])))
+        self._set_only_if_by_name('relationship', obj, Relationships)
         self._set_only_if(
             'user', obj, 'user',
             lambda: Users.get(Users.id == obj['user'])

--- a/pacifica/metadata/orm/transaction_user.py
+++ b/pacifica/metadata/orm/transaction_user.py
@@ -57,8 +57,7 @@ class TransactionUser(CherryPyAPI):
         super(TransactionUser, self).from_hash(obj)
         self._set_only_if('uuid', obj, 'uuid',
                           lambda: uuid.UUID(obj['uuid']))
-        self._set_only_if('relationship', obj, 'relationship',
-                          lambda: Relationships.get(Relationships.uuid == uuid.UUID(obj['relationship'])))
+        self._set_only_if_by_name('relationship', obj, Relationships)
         self._set_only_if('transaction', obj, 'transaction',
                           lambda: Transactions.get(Transactions.id == obj['transaction']))
         self._set_only_if('user', obj, 'user',


### PR DESCRIPTION
### Description

This allows users to create relationships by name or UUID so they
don't have to look up the UUID for these cross reference objects.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
