### PR TITLE
Move event emit code to common module.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v1.4.4
     hooks:
             -   id: autopep8
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace

--- a/pacifica/metadata/config.py
+++ b/pacifica/metadata/config.py
@@ -32,6 +32,12 @@ def get_config():
         'NOTIFICATIONS_DISABLED', 'False'))
     configparser.set('notifications', 'url', getenv(
         'NOTIFICATIONS_URL', 'http://127.0.0.1:8070/receive'))
+    configparser.set('notifications', 'ingest_eventtype', getenv(
+        'NOTIFICATIONS_INGEST_EVENT_TYPE', 'org.pacifica.metadata.ingest'))
+    configparser.set('notifications', 'ingest_source', getenv(
+        'NOTIFICATIONS_INGEST_SOURCE', 'http://metadata.pacifica.org/transactions?_id={_id}'))
+    configparser.set('notifications', 'ingest_eventid', getenv(
+        'NOTIFICATIONS_INGEST_EVENTID', 'metadata.ingest.{_id}'))
     configparser.read(CONFIG_FILE)
     return configparser
 

--- a/pacifica/metadata/config.py
+++ b/pacifica/metadata/config.py
@@ -44,6 +44,18 @@ def get_config():
         'NOTIFICATIONS_ORM_SOURCE', 'http://metadata.pacifica.org/{object_name}'))
     configparser.set('notifications', 'orm_eventid', getenv(
         'NOTIFICATIONS_ORM_EVENTID', 'metadata.orm.{object_name}.{uuid}'))
+    configparser.set('notifications', 'doientry_eventtype', getenv(
+        'NOTIFICATIONS_DOIENTRY_EVENT_TYPE', 'org.pacifica.metadata.doientry'))
+    configparser.set('notifications', 'doientry_source', getenv(
+        'NOTIFICATIONS_DOIENTRY_SOURCE', 'http://metadata.pacifica.org/doientry'))
+    configparser.set('notifications', 'doientry_eventid', getenv(
+        'NOTIFICATIONS_DOIENTRY_EVENTID', 'metadata.doi.{uuid}'))
+    configparser.set('notifications', 'doiupdate_eventtype', getenv(
+        'NOTIFICATIONS_DOIUPDATE_EVENT_TYPE', 'org.pacifica.metadata.doiupdate'))
+    configparser.set('notifications', 'doiupdate_source', getenv(
+        'NOTIFICATIONS_DOIUPDATE_SOURCE', 'http://metadata.pacifica.org/doientry?doi={doi}'))
+    configparser.set('notifications', 'doiupdate_eventid', getenv(
+        'NOTIFICATIONS_DOIUPDATE_EVENTID', 'metadata.doi.{doi}.{uuid}'))
     configparser.read(CONFIG_FILE)
     return configparser
 

--- a/pacifica/metadata/config.py
+++ b/pacifica/metadata/config.py
@@ -38,6 +38,12 @@ def get_config():
         'NOTIFICATIONS_INGEST_SOURCE', 'http://metadata.pacifica.org/transactions?_id={_id}'))
     configparser.set('notifications', 'ingest_eventid', getenv(
         'NOTIFICATIONS_INGEST_EVENTID', 'metadata.ingest.{_id}'))
+    configparser.set('notifications', 'orm_eventtype', getenv(
+        'NOTIFICATIONS_ORM_EVENT_TYPE', 'org.pacifica.metadata.orm'))
+    configparser.set('notifications', 'orm_source', getenv(
+        'NOTIFICATIONS_ORM_SOURCE', 'http://metadata.pacifica.org/{object_name}?{args}'))
+    configparser.set('notifications', 'orm_eventid', getenv(
+        'NOTIFICATIONS_ORM_EVENTID', 'metadata.orm.{object_name}.{uuid}'))
     configparser.read(CONFIG_FILE)
     return configparser
 

--- a/pacifica/metadata/config.py
+++ b/pacifica/metadata/config.py
@@ -41,7 +41,7 @@ def get_config():
     configparser.set('notifications', 'orm_eventtype', getenv(
         'NOTIFICATIONS_ORM_EVENT_TYPE', 'org.pacifica.metadata.orm'))
     configparser.set('notifications', 'orm_source', getenv(
-        'NOTIFICATIONS_ORM_SOURCE', 'http://metadata.pacifica.org/{object_name}?{args}'))
+        'NOTIFICATIONS_ORM_SOURCE', 'http://metadata.pacifica.org/{object_name}'))
     configparser.set('notifications', 'orm_eventid', getenv(
         'NOTIFICATIONS_ORM_EVENTID', 'metadata.orm.{object_name}.{uuid}'))
     configparser.read(CONFIG_FILE)

--- a/pacifica/metadata/rest/doi_queries/doi_registration_entry.py
+++ b/pacifica/metadata/rest/doi_queries/doi_registration_entry.py
@@ -2,11 +2,14 @@
 # -*- coding: utf-8 -*-
 """CherryPy DOI Registration Updater object class."""
 from __future__ import print_function
+from uuid import uuid4
 from cherrypy import tools, request, HTTPError
-from pacifica.metadata.rest.user_queries.user_search import UserSearch
-from pacifica.metadata.rest.doi_queries.doi_registration_base import DOIRegistrationBase
-from pacifica.metadata.orm import DOITransaction, TransactionUser, DOIInfo, Relationships
-from pacifica.metadata.orm.base import DB
+from ...config import get_config
+from ...orm.base import DB
+from ...orm import DOITransaction, TransactionUser, DOIInfo, Relationships
+from ..user_queries.user_search import UserSearch
+from ..events import emit_event
+from .doi_registration_base import DOIRegistrationBase
 # pylint: disable=too-few-public-methods
 
 
@@ -85,4 +88,10 @@ class DOIRegistrationEntry(DOIRegistrationBase):
                 'entry': new_entry,
                 'was_created': _created
             })
+        emit_event(
+            eventType=get_config().get('notifications', 'doientry_eventtype'),
+            source=get_config().get('notifications', 'doientry_source'),
+            eventID=get_config().get('notifications', 'doientry_eventid').format(uuid=uuid4()),
+            data=new_entries_info
+        )
         return new_entries_info

--- a/pacifica/metadata/rest/events.py
+++ b/pacifica/metadata/rest/events.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Emit events for different things."""
+from datetime import datetime
+import logging
+from json import dumps
+import requests
+from requests import RequestException
+from ..config import get_config
+
+
+def emit_event(**kwargs):
+    """Emit a cloud event that the data is now accepted."""
+    try:
+        resp = requests.post(
+            get_config().get('notifications', 'url'),
+            data=dumps({
+                'cloudEventsVersion': '0.1',
+                'eventType': kwargs.get('eventType'),
+                'source': kwargs.get('source'),
+                'eventID': kwargs.get('eventID'),
+                'eventTime': datetime.now().replace(microsecond=0).isoformat(),
+                'extensions': kwargs.get('extensions', {}),
+                'contentType': 'application/json',
+                'data': kwargs.get('data', {})
+            }),
+            headers={'Content-Type': 'application/json'}
+        )
+        resp_major = int(int(resp.status_code)/100)
+        assert resp_major == 2
+    except (RequestException, AssertionError) as ex:
+        logging.warning('Unable to send notification: %s', ex)

--- a/pacifica/metadata/rest/orm.py
+++ b/pacifica/metadata/rest/orm.py
@@ -1,11 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """Core interface for each ORM object to interface with CherryPy."""
-try:
-    from urllib import urlencode
-except ImportError:  # pragma: no cover only python 2/3
-    from urllib.parse import urlencode
 from uuid import uuid4
+import json
 import cherrypy
 from cherrypy import HTTPError
 from peewee import DoesNotExist
@@ -49,26 +46,21 @@ class CherryPyAPI(PacificaModel):
                 ret[pkey] = obj.to_hash()[pkey]
         return ret
 
-    @classmethod
-    def _primary_keys_as_getargs(cls, obj):
-        """Return primary keys as get args."""
-        return urlencode(cls._primary_keys_as_dict(obj))
-
-    def _send_orm_event(self, obj, method):
+    @staticmethod
+    def _send_orm_event(obj_cls, objs, method):
         if not get_config().getboolean('notifications', 'disabled'):
             emit_event(
                 eventType=get_config().get('notifications', 'orm_eventtype'),
                 source=get_config().get('notifications', 'orm_source').format(
-                    object_name=obj.get_object_info()['callable_name'],
-                    args=self._primary_keys_as_getargs(obj)
+                    object_name=obj_cls.get_object_info()['callable_name']
                 ),
                 eventID=get_config().get('notifications', 'orm_eventid').format(
-                    object_name=obj.get_object_info()['callable_name'],
+                    object_name=obj_cls.get_object_info()['callable_name'],
                     uuid=uuid4()
                 ),
                 data={
-                    'obj_type': obj.get_object_info()['callable_name'],
-                    'obj_primary_keys': self._primary_keys_as_dict(obj),
+                    'obj_type': obj_cls.get_object_info()['callable_name'],
+                    'obj_primary_keys': objs,
                     'method': method
                 }
             )
@@ -106,13 +98,21 @@ class CherryPyAPI(PacificaModel):
         update_hash['updated'] = update_hash.get(
             'updated', datetime_now_nomicrosecond())
         did_something = False
-        for obj in self.select().where(self.where_clause(kwargs)):
-            self._send_orm_event(obj, 'update')
+        query = self.select().where(self.where_clause(kwargs))
+        for obj in query:
             did_something = True
             obj.from_hash(update_hash)
             obj.save()
         if not did_something:
             raise HTTPError(500, "Get args didn't select any objects.")
+        self._send_orm_event(
+            self.__class__,
+            [
+                self._primary_keys_as_dict(obj)
+                for obj in query
+            ],
+            'update'
+        )
 
     def _set_or_create(self, objs):
         """Set or create the object if it doesn't already exist."""
@@ -153,11 +153,25 @@ class CherryPyAPI(PacificaModel):
         # this is a PostgreSQL specific option...
         # pylint: disable=no-value-for-parameter
         id_list = self.__class__.insert_many(clean_objs).execute()
+        clean_id_list = []
+        for obj_ids in id_list:
+            new_objids = []
+            for obj_id in obj_ids:
+                try:
+                    json.dumps(obj_id)
+                    new_objids.append(obj_id)
+                except TypeError:
+                    new_objids.append(str(obj_id))
+            clean_id_list.append(new_objids)
         # pylint: enable=no-value-for-parameter
-        if not get_config().getboolean('notifications', 'disabled'):
-            for obj_ids in id_list:
-                obj = self.select().where(self.where_clause(dict(zip(self.get_primary_keys(), obj_ids))))[0]
-                self._send_orm_event(obj, 'insert')
+        self._send_orm_event(
+            self.__class__,
+            [
+                dict(zip(self.get_primary_keys(), obj_ids))
+                for obj_ids in clean_id_list
+            ],
+            'insert'
+        )
 
     @classmethod
     def check_for_key_existence(cls, object_list):
@@ -193,9 +207,17 @@ class CherryPyAPI(PacificaModel):
     def _force_delete(self, **kwargs):
         """Force delete entries in the database."""
         recursive = kwargs.pop('recursive', False)
-        for obj in self.select().where(self.where_clause(kwargs)):
-            self._send_orm_event(obj, 'delete')
+        query = self.select().where(self.where_clause(kwargs))
+        for obj in query:
             obj.delete_instance(recursive)
+        self._send_orm_event(
+            self.__class__,
+            [
+                self._primary_keys_as_dict(obj)
+                for obj in query
+            ],
+            'delete'
+        )
 
     def _delete(self, **kwargs):
         """Internal delete object method."""


### PR DESCRIPTION
This moves the event emit code to a central module so it can be
used elsewhere in the code.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
