### PR TITLE
Fix #226 UserInfo lookup fix

### DIFF
--- a/pacifica/metadata/rest/user_queries/query_base.py
+++ b/pacifica/metadata/rest/user_queries/query_base.py
@@ -12,7 +12,7 @@ class QueryBase(object):
         """Construct a dictionary from a given user instance in the metadata stack."""
         user_hash = user_entry.to_hash()
         project_xref = ProjectUser()
-        where_exp = project_xref.where_clause({'person_id': user_entry.id})
+        where_exp = project_xref.where_clause({'user': user_entry.id})
         project_person_query = (
             ProjectUser.select().where(where_exp)).dicts()
 


### PR DESCRIPTION
### Description

Changing the user lookup query to use "user" in the where clause, not "person". We probably want to double-check the remainder of the rest queries to make sure that we didn't miss anybody else.

### Issues Resolved

Fix #226 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable