### PR TITLE
Fix #225 Add UUID check for json serialization

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -265,6 +265,8 @@ class PacificaModel(Model):
             # pylint: enable=no-value-for-parameter
             inst_key = index_hash(*obj.values())
             hash_list.append(inst_key)
+            if 'uuid' in obj:
+                obj['uuid'] = str(obj['uuid'])
             entry = {
                 'key_list': obj,
                 'index_hash': inst_key

--- a/tests/rest/objectinfo_test.py
+++ b/tests/rest/objectinfo_test.py
@@ -11,7 +11,7 @@ class TestObjectInfoAPI(CPCommonTest):
 
     __test__ = True
 
-    def test_objectinfo_api(self):
+    def test_objectinfo_api_basic(self):
         """Test the GET method."""
         req = requests.get(
             '{0}/objectinfo?object_class_name=list'.format(self.url))
@@ -34,6 +34,12 @@ class TestObjectInfoAPI(CPCommonTest):
         req_json = loads(req.text)
         self.assertTrue('hash_list' in req_json)
         self.assertTrue('hash_lookup' in req_json)
+
+    def test_objectinfo_api_complex(self):
+        """Test the GET method."""
+        req = requests.get(
+            '{0}/objectinfo/project_user/hashlist'.format(self.url))
+        self.assertEqual(req.status_code, 200)
 
     def test_bad_objectinfo_api(self):
         """Test the GET method with bad data."""


### PR DESCRIPTION
### Description

UUIDs should be serialized by just using str() on them.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved
Fix #225 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
