### PR TITLE
Mapping tables key fixes

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -18,7 +18,7 @@ and deleting these objects in from a web service layer.
 import datetime
 import uuid
 from dateutil import parser
-from peewee import Model, Expression, OP, AutoField, fn, CompositeKey, SQL, NodeList, BackrefAccessor
+from peewee import Model, Expression, OP, AutoField, fn, SQL, NodeList, BackrefAccessor
 from six import text_type
 from .utils import index_hash, ExtendDateTimeField
 from .utils import datetime_converts, date_converts, datetime_now_nomicrosecond

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -281,6 +281,9 @@ class PacificaModel(Model):
         primary_key = cls._meta.primary_key
         if isinstance(primary_key, CompositeKey) and cls._meta.refs:
             return list(primary_key.field_names)
+        elif primary_key.name == 'uuid':
+            keys = [x.name for x in cls._meta.refs if x.name != 'relationship']
+            return keys
         # pylint: enable=no-member
         return [primary_key.name]
 

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -279,13 +279,13 @@ class PacificaModel(Model):
         """Return the primary keys for the object."""
         # pylint: disable=no-member
         primary_key = cls._meta.primary_key
+        keys = [primary_key.name]
         if isinstance(primary_key, CompositeKey) and cls._meta.refs:
-            return list(primary_key.field_names)
+            keys = list(primary_key.field_names)
         elif primary_key.name == 'uuid':
             keys = [x.name for x in cls._meta.refs if x.name != 'relationship']
-            return keys
         # pylint: enable=no-member
-        return [primary_key.name]
+        return keys
 
     @classmethod
     def get_object_info(cls, where_clause=None):

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -278,18 +278,11 @@ class PacificaModel(Model):
     def get_primary_keys(cls):
         """Return the primary keys for the object."""
         # pylint: disable=no-member
-        primary_key = cls._meta.primary_key
-        keys = [primary_key.name]
-        if isinstance(primary_key, CompositeKey) and cls._meta.refs:
-            keys = list(primary_key.field_names)
-        elif primary_key.name == 'uuid':
-            keys = PacificaModel._extract_meta_refs(cls._meta_refs)
+        key_objects = [cls._meta.primary_key]
+        key_objects.extend(list(cls._meta.refs))
+        keys = [x.name for x in key_objects if x.name not in ['relationship', 'uuid', '__composite_key__']]
         # pylint: enable=no-member
         return keys
-
-    @staticmethod
-    def _extract_meta_refs(meta_refs):
-        return [x.name for x in meta_refs if x.name != 'relationship']
 
     @classmethod
     def get_object_info(cls, where_clause=None):

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -265,8 +265,6 @@ class PacificaModel(Model):
             # pylint: enable=no-value-for-parameter
             inst_key = index_hash(*obj.values())
             hash_list.append(inst_key)
-            if 'uuid' in obj:
-                obj['uuid'] = str(obj['uuid'])
             entry = {
                 'key_list': obj,
                 'index_hash': inst_key

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -283,9 +283,13 @@ class PacificaModel(Model):
         if isinstance(primary_key, CompositeKey) and cls._meta.refs:
             keys = list(primary_key.field_names)
         elif primary_key.name == 'uuid':
-            keys = [x.name for x in cls._meta.refs if x.name != 'relationship']
+            keys = PacificaModel._extract_meta_refs(cls._meta_refs)
         # pylint: enable=no-member
         return keys
+
+    @staticmethod
+    def _extract_meta_refs(meta_refs):
+        return [x.name for x in meta_refs if x.name != 'relationship']
 
     @classmethod
     def get_object_info(cls, where_clause=None):


### PR DESCRIPTION
### Description

Changing the way that mapping tables have their values hashed. This looks at the foreign-key relationships in the table, but removes the "relationship" and "uuid" columns, as they aren't part of the EUS schema that we're comparing against.

### Issues Resolved

Fixes #236 

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
