### PR TITLE
Remove Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 services:
 - elasticsearch
 cache:
@@ -32,13 +32,8 @@ jobs:
     python: 3.6
     before_script: skip
     script: pre-commit run -a
-  - python: 2.7
-    before_script: skip
-    script: pre-commit run -a
   - stage: test
     python: 3.6
-    sudo: required
-  - python: 2.7
     sudo: required
   - stage: test-migration
     python: 3.6
@@ -97,21 +92,6 @@ jobs:
       provider: pypi
       user: dmlb2000
       distributions: sdist bdist_wheel
-      password:
-        secure: QldhKXUmkWsrHuI0JLEmN65A5nwC2JqG4r80BwmAyAVYSJ3OOX3a91S0N30hUL3/BZp12+0VUwyLYYfwFvOGx5lymkmjLQXtgT/tUFHnyci1JPsBK3KmSNixqGzRQGvtuiSVutXmuD5+pAR2RoZ0NcPUPwZ8wZ/Xqgq6YdSO7EpqT607F+eV8lOZzamMkrZ2qESf17w3KmCbzwNupiGUyWBd2SuPCgQS9K8hjwye0oPijSUsqTTkHKr5hEsmdv1eUbLAGZzoEMZyyXYpSsIu0X6DBZRt1k5m9XEw2wQlVeNeayPlgva/QlswzcUbdCZUpAKcaTm8X2pzSfYdzX3VksqyGHHeC93HiHZBLkVlqa4H1aHJPLJRZp0kvadq1DQWO1rh8gWl/QhKiqDk8J4KqsFaoW8aFK+x0YANJXitQJ5xQve85QY/d+M9hHPgkawHbhkssbVLAjzLgvUpbvcRgghmZ6/Aafo74KXuxfAtp4xThEYXT0zoVzULgVHYMWJFNeLLvimvjRozgbC98mqr5lFxhQG9vmTX5hB/AcljisdOzHrPftyZPvSFMqgdiJjqcHrf5uuVBP5JAxM7PKqCHXTtxzTgEi58H/CFzAf1/2Vnh07nN31/5IdNwttonzb2EdbToz3ReCIf8roQGnt/hhNi9UiupOe9cFvXoWCWmZk=
-      on:
-        tags: true
-  - services: []
-    language: python
-    before_install: skip
-    before_script: skip
-    script: skip
-    python: 2.7
-    deploy:
-      skip_cleanup: true
-      provider: pypi
-      user: dmlb2000
-      distributions: bdist_wheel
       password:
         secure: QldhKXUmkWsrHuI0JLEmN65A5nwC2JqG4r80BwmAyAVYSJ3OOX3a91S0N30hUL3/BZp12+0VUwyLYYfwFvOGx5lymkmjLQXtgT/tUFHnyci1JPsBK3KmSNixqGzRQGvtuiSVutXmuD5+pAR2RoZ0NcPUPwZ8wZ/Xqgq6YdSO7EpqT607F+eV8lOZzamMkrZ2qESf17w3KmCbzwNupiGUyWBd2SuPCgQS9K8hjwye0oPijSUsqTTkHKr5hEsmdv1eUbLAGZzoEMZyyXYpSsIu0X6DBZRt1k5m9XEw2wQlVeNeayPlgva/QlswzcUbdCZUpAKcaTm8X2pzSfYdzX3VksqyGHHeC93HiHZBLkVlqa4H1aHJPLJRZp0kvadq1DQWO1rh8gWl/QhKiqDk8J4KqsFaoW8aFK+x0YANJXitQJ5xQve85QY/d+M9hHPgkawHbhkssbVLAjzLgvUpbvcRgghmZ6/Aafo74KXuxfAtp4xThEYXT0zoVzULgVHYMWJFNeLLvimvjRozgbC98mqr5lFxhQG9vmTX5hB/AcljisdOzHrPftyZPvSFMqgdiJjqcHrf5uuVBP5JAxM7PKqCHXTtxzTgEi58H/CFzAf1/2Vnh07nN31/5IdNwttonzb2EdbToz3ReCIf8roQGnt/hhNi9UiupOe9cFvXoWCWmZk=
       on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
   NOTIFICATIONS_URL: http://127.0.0.1:8080
   PEEWEE_URL: postgres://postgres:Password12!@localhost/pacifica_metadata
   matrix:
-  - PYTHON: C:\Python27-x64
   - PYTHON: C:\Python36-x64
 
 install:

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -20,7 +20,6 @@ import uuid
 from collections import OrderedDict
 from dateutil import parser
 from peewee import Model, Expression, OP, AutoField, fn, CompositeKey, SQL, NodeList, BackrefAccessor
-from six import text_type
 from .utils import index_hash, ExtendDateTimeField
 from .utils import datetime_converts, date_converts, datetime_now_nomicrosecond
 from .globals import DB
@@ -247,7 +246,7 @@ class PacificaModel(Model):
             if last_change_date is not None else '1970-01-01 00:00:00'
         last_change_string = last_change_date.isoformat(' ') \
             if isinstance(last_change_date, datetime.datetime) else parser.parse(last_change_string).isoformat(' ')
-        return text_type(last_change_string)
+        return str(last_change_string)
 
     @classmethod
     def available_hash_list(cls, columns_and_where_clause=None):

--- a/pacifica/metadata/rest/fileinfo_queries/file_details.py
+++ b/pacifica/metadata/rest/fileinfo_queries/file_details.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """CherryPy File Details object class."""
-from six import text_type
 from cherrypy import tools, HTTPError, request
 from pacifica.metadata.orm import Files
 
@@ -21,7 +20,7 @@ class FileDetailsLookup(object):
             raise HTTPError('404 Not Found', message)
         return [{
             'file_id': f.id,
-            'relative_local_path': text_type('{0}/{1}').format(f.subdir.rstrip('/'), f.name),
+            'relative_local_path': str('{0}/{1}').format(f.subdir.rstrip('/'), f.name),
             'file_size_bytes': f.size,
             'hashtype': f.hashtype,
             'hashsum': f.hashsum

--- a/pacifica/metadata/rest/ingest.py
+++ b/pacifica/metadata/rest/ingest.py
@@ -37,7 +37,6 @@ Example uploaded data::
 """
 from __future__ import print_function
 import hashlib
-from six import binary_type
 from cherrypy import request, tools
 from pacifica.metadata.config import get_config
 from pacifica.metadata.orm.transsip import TransSIP
@@ -82,7 +81,7 @@ class IngestAPI(object):
         except ValueError:
             return False
         hashd = getattr(hashlib, hashtype)()
-        hashd.update(binary_type())
+        hashd.update(b'')
         if len(hashsum) != len(hashd.hexdigest()):
             return False
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ peewee>2
 psycopg2
 python-dateutil
 requests
-six


### PR DESCRIPTION
### Description

This removes Python 2.7 support from Travis CI and Appveyor. This
also removes the six requirements as we are not supporting Python
2.7 anymore.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
