### PR TITLE
Add Python 3.7 and 3.8 to Travis CI and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: bionic
 services:
 - elasticsearch
+python: 3.6
 cache:
   directories:
   - $HOME/.cache/pre-commit
@@ -29,14 +30,21 @@ before_script:
 jobs:
   include:
   - stage: lint
-    python: 3.6
-    before_script: skip
+    script: pre-commit run -a
+  - python: 3.7
+    script: pre-commit run -a
+  - python: 3.8
     script: pre-commit run -a
   - stage: test
-    python: 3.6
     sudo: required
+  - python: 3.7
+  - python: 3.8
+    script:
+      - coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -m pytest -xv tests/orm
+      - coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -a -m pytest -xv tests/core
+      - coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -a -m pytest -xv tests/rest
+      - coverage report -m --fail-under 100
   - stage: test-migration
-    python: 3.6
     sudo: required
     script: >
       curl -o apgdiff.zip https://www.apgdiff.com/download/apgdiff-2.4-bin.zip;
@@ -54,7 +62,7 @@ jobs:
       if [[ $(java -jar apgdiff-2.4/apgdiff-2.4.jar update_schema.dump.sql orig_schema.dump.sql | wc -l) -gt 0 ]] ; then exit -1; fi
   - stage: test-docker
     sudo: required
-    python: 3.6
+    python: 3.8
     services:
     - docker
     before_script: skip
@@ -71,7 +79,7 @@ jobs:
       pip install .;
       cd tests; python test_files/loadit_test.py
   - stage: test-docs
-    python: 3.6
+    python: 3.8
     before_script: skip
     script: >
       pip install .;
@@ -86,7 +94,7 @@ jobs:
     before_install: skip
     before_script: skip
     script: skip
-    python: 3.6
+    python: 3.8
     deploy:
       skip_cleanup: true
       provider: pypi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
   PEEWEE_URL: postgres://postgres:Password12!@localhost/pacifica_metadata
   matrix:
   - PYTHON: C:\Python36-x64
+  - PYTHON: C:\Python37-x64
+  - PYTHON: C:\Python38-x64
 
 install:
 - ps: >
@@ -43,7 +45,7 @@ test_script:
     mkdir C:\tmp; C:\pacifica\Scripts\activate.ps1;
     $es_proc = Start-Process C:\elasticsearch\elasticsearch-5.6.14\bin\elasticsearch -PassThru;
     pre-commit run -a;
-    coverage run --include='pacifica/metadata/*' -m pytest -xv tests/orm;
-    coverage run --include='pacifica/metadata/*' -a -m pytest -xv tests/core;
-    coverage run --include='pacifica/metadata/*' -a -m pytest -xv tests/rest;
+    coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -m pytest -xv tests/orm;
+    coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -a -m pytest -xv tests/core;
+    coverage run --include='pacifica/metadata/*' --omit='pacifica/metadata/admin_cmd*,pacifica/metadata/orm/sync*' -a -m pytest -xv tests/rest;
     coverage report -m --fail-under=100;

--- a/tests/core/cmd_test.py
+++ b/tests/core/cmd_test.py
@@ -11,6 +11,7 @@ import zipfile
 from unittest import TestCase
 from tempfile import mkdtemp
 from shutil import rmtree
+import pytest
 try:
     import sh
 except ImportError:
@@ -54,7 +55,12 @@ def requests_retry_session(retries=3, backoff_factor=0.5, status_forcelist=(500,
     session.mount('https://', adapter)
     return session
 
-
+# This is backwards compatibility testing issues.
+#
+# The complication here is that older versions of the metadata service can't install
+# in Python versions > 3.7. The psycopg2 package required for those older versions
+# do not compile against Python > 3.7.
+@pytest.mark.skipif(sys.version_info > (3, 8), reason='requires python3.7 or less')
 class AdminCmdBase:
     """Test base class for setting up update environments."""
 


### PR DESCRIPTION
### Description

This adds Python 3.7 and 3.8 to Travis CI and Appveyor CI/CD
pipelines.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
