### PR TITLE
Fixing query logic for transaction summary reporting

### DIFF
--- a/pacifica/metadata/rest/reporting_queries/transaction_reporting.py
+++ b/pacifica/metadata/rest/reporting_queries/transaction_reporting.py
@@ -48,10 +48,6 @@ class TransactionReporting(QueryBase):
             .group_by(TransSIP.project, TransSIP.instrument)
             .order_by(TransSIP.project, TransSIP.instrument))
 
-
-
-        print("transsip select =>")
-        print(transaction_query.sql())
         # pylint: enable=no-member
         transaction_results = defaultdict(dict)
 


### PR DESCRIPTION

### Description

Switching around the selection logic for the transaction summary query that is used for the Compliance Reporting tool

### Issues Resolved

Fixes #274 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
