### PR TITLE
Filtering out "soft deleted" entries.

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,17 +209,18 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
-        if 'include_deleted' not in kwargs and 'deleted' not in kwargs:
-            where_clause &= Expression(
-                getattr(cls, 'deleted'), OP.IS, None)
+        # if 'include_deleted' not in kwargs and 'deleted' not in kwargs:
+        #     where_clause &= Expression(
+        #         getattr(cls, 'deleted'), OP.IS, None)
         if 'deleted' in kwargs:
-            if kwargs['deleted'] is None:
-                where_clause &= Expression(
-                    getattr(cls, 'deleted'), OP.IS, None)
-            else:
+            if kwargs['deleted']:
                 date_obj = datetime_converts(kwargs['deleted'])
                 where_clause &= Expression(
-                    getattr(cls, 'deleted'), OP.EQ, date_obj)
+                getattr(cls, 'deleted'), OP.EQ, date_obj)
+            else:
+                where_clause &= Expression(
+                    getattr(cls, 'deleted'), OP.IS, None)
+
         for date in ['updated', 'created']:
             if date in kwargs:
                 date_obj, date_oper = cls._date_operator_compare(date, kwargs)

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -212,6 +212,10 @@ class PacificaModel(Model):
         if 'deleted' not in kwargs:
             where_clause &= Expression(
                 getattr(cls, 'deleted'), OP.IS, None)
+        elif kwargs['deleted']:
+            date_obj = datetime_converts(kwargs['deleted'])
+            where_clause &= Expression(
+                getattr(cls, 'deleted'), OP.EQ, date_obj)
 
         for date in ['updated', 'created']:
             if date in kwargs:

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -266,8 +266,6 @@ class PacificaModel(Model):
         # all_keys_query = cls.select(*[getattr(cls, key) for key in columns])
         all_keys_query = cls.select().where(cls.where_clause(where_clause))
 
-        print(all_keys_query.sql())
-
         # pylint: disable=no-value-for-parameter
         for entry in all_keys_query.execute():
             # pylint: enable=no-value-for-parameter

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -216,7 +216,7 @@ class PacificaModel(Model):
             if kwargs['deleted']:
                 date_obj = datetime_converts(kwargs['deleted'])
                 where_clause &= Expression(
-                getattr(cls, 'deleted'), OP.EQ, date_obj)
+                    getattr(cls, 'deleted'), OP.EQ, date_obj)
             else:
                 where_clause &= Expression(
                     getattr(cls, 'deleted'), OP.IS, None)

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,14 +209,9 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
-        if 'deleted' in kwargs:
-            if kwargs['deleted']:
-                date_obj = datetime_converts(kwargs['deleted'])
-                where_clause &= Expression(
-                    getattr(cls, 'deleted'), OP.EQ, date_obj)
-            else:
-                where_clause &= Expression(
-                    getattr(cls, 'deleted'), OP.IS, None)
+        if 'deleted' not in kwargs:
+            where_clause &= Expression(
+                getattr(cls, 'deleted'), OP.IS, None)
 
         for date in ['updated', 'created']:
             if date in kwargs:
@@ -257,7 +252,10 @@ class PacificaModel(Model):
         This structure allows for easy evaluation of updates or current vs old data
         for any object in the database.
         """
+
         where_clause = {k: v for k, v in columns_and_where_clause.items() if v}
+        where_clause['deleted'] = None
+
         columns = list(columns_and_where_clause.keys())
 
         if not columns:
@@ -268,6 +266,8 @@ class PacificaModel(Model):
         hash_dict = {}
         # all_keys_query = cls.select(*[getattr(cls, key) for key in columns])
         all_keys_query = cls.select().where(cls.where_clause(where_clause))
+
+        print(all_keys_query.sql())
 
         # pylint: disable=no-value-for-parameter
         for entry in all_keys_query.execute():

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,9 +209,6 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
-        # if 'include_deleted' not in kwargs and 'deleted' not in kwargs:
-        #     where_clause &= Expression(
-        #         getattr(cls, 'deleted'), OP.IS, None)
         if 'deleted' in kwargs:
             if kwargs['deleted']:
                 date_obj = datetime_converts(kwargs['deleted'])

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,9 +209,9 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
-            if 'deleted' not in kwargs:
-                where_clause &= Expression(
-                    getattr(cls, 'deleted'), OP.IS, None)
+        if 'deleted' not in kwargs:
+            where_clause &= Expression(
+                getattr(cls, 'deleted'), OP.IS, None)
 
         for date in ['updated', 'created']:
             if date in kwargs:

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,6 +209,9 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
+        if 'include_deleted' not in kwargs and 'deleted' not in kwargs:
+            where_clause &= Expression(
+                getattr(cls, 'deleted'), OP.IS, None)
         if 'deleted' in kwargs:
             if kwargs['deleted'] is None:
                 where_clause &= Expression(

--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -209,9 +209,9 @@ class PacificaModel(Model):
     def where_clause(cls, kwargs):
         """PeeWee specific extension meant to be passed to a PeeWee get or select."""
         where_clause = Expression(1, OP.EQ, 1)
-        if 'deleted' not in kwargs:
-            where_clause &= Expression(
-                getattr(cls, 'deleted'), OP.IS, None)
+            if 'deleted' not in kwargs:
+                where_clause &= Expression(
+                    getattr(cls, 'deleted'), OP.IS, None)
 
         for date in ['updated', 'created']:
             if date in kwargs:
@@ -252,7 +252,6 @@ class PacificaModel(Model):
         This structure allows for easy evaluation of updates or current vs old data
         for any object in the database.
         """
-
         where_clause = {k: v for k, v in columns_and_where_clause.items() if v}
         where_clause['deleted'] = None
 

--- a/tests/orm/base_test.py
+++ b/tests/orm/base_test.py
@@ -134,7 +134,10 @@ class TestBase(TestCase):
         """
         obj = self.base_create_obj(self.obj_cls, obj_hash)
         for (key, val) in obj_hash.items():
-            chk_obj = self.base_where_clause_search(obj, {key: val})[0]
+            test_kwargs = {key: val}
+            if key != 'deleted':
+                test_kwargs['deleted'] = None
+            chk_obj = self.base_where_clause_search(obj, test_kwargs)[0]
             chk_obj_hash = chk_obj.to_hash()
             for chkkey in obj_hash.keys():
                 self.assertEqual(

--- a/tests/orm/dbdates_test.py
+++ b/tests/orm/dbdates_test.py
@@ -91,7 +91,7 @@ class TestDBDates(TestBase):
             'created_operator': 'LT'
         }
         objs = self.base_where_clause_search(third_obj, search_expr)
-        self.assertEqual(len(objs), 2)
+        self.assertEqual(len(objs), 1)
         search_expr = {
             'created': '0',
             'created_0': date_check_min.replace(microsecond=0).isoformat(),


### PR DESCRIPTION
### Description

Minor addition to orm/base.py to enable the system to filter out soft deleted entries (entries with a non-null deleted date). 

This just "makes sense" to me. The system shouldn't show anything that has been "deleted" unless you specifically ask it to do so (by adding a query param of "include_deleted"

### Issues Resolved

Fixes #273 

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
