### PR TITLE
Update exampleusage.md

### DIFF
--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -26,10 +26,10 @@ store the JSON data:
 ```
 
 Then, provide the contents of the new file as the body for a HTTP PUT request
-using the `curl` command:
+using the `curl` command with the HTTP header specified:
 
 ```sh
-curl -X PUT -T create.json 'http://localhost:8121/users'
+curl -H 'Content-Type: application/json' -X PUT -T create.json 'http://localhost:8121/users'
 ```
 
 ### Reading an Object
@@ -138,7 +138,7 @@ Then, provide the contents of the new file as the body for a HTTP POST request
 using the `curl` command:
 
 ```sh
-curl -X POST -T update.json 'http://localhost:8121/users?last_name=Doe&first_name=John'
+curl -H 'Content-Type: application/json' -X POST -T update.json 'http://localhost:8121/users?last_name=Doe&first_name=John'
 ```
 
 Finally, verify the modifications by retrieving the most recent version of the


### PR DESCRIPTION
Specifying the header appears to be required otherwise it will fail with a 405 error. 
Adding to the curl  -H 'Content-Type: application/json'  works properly.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
