### PR TITLE
Changes to fix issues with the upload-status tool

### DIFF
--- a/tests/core/client_test.py
+++ b/tests/core/client_test.py
@@ -303,4 +303,4 @@ class TestClient(TestCase):
             client.update(class_type, params, post_body)
         except PMClientError as ex:
             self.assertTrue('301' in str(ex))
-            self.assertTrue('This is the error.'in str(ex))
+            self.assertTrue('This is the error.' in str(ex))

--- a/tests/core/cmd_test.py
+++ b/tests/core/cmd_test.py
@@ -60,6 +60,8 @@ def requests_retry_session(retries=3, backoff_factor=0.5, status_forcelist=(500,
 # The complication here is that older versions of the metadata service can't install
 # in Python versions > 3.7. The psycopg2 package required for those older versions
 # do not compile against Python > 3.7.
+
+
 @pytest.mark.skipif(sys.version_info > (3, 8), reason='requires python3.7 or less')
 class AdminCmdBase:
     """Test base class for setting up update environments."""


### PR DESCRIPTION
Adding in some logic to limit returned projects to those for which the user is tagged as "member_of"

### Description

The "get_projects_for_user" logic was returning duplicates of project info for searches by user_id. This was due to the user having multiple relationships with the same project. Added in another join in the function that pulls in the member_of relationship and uses it as an additional filter

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
