### PR TITLE
Fixing object hash generator

### DIFF
--- a/pacifica/metadata/orm/base.py
+++ b/pacifica/metadata/orm/base.py
@@ -257,7 +257,6 @@ class PacificaModel(Model):
         for any object in the database.
         """
         where_clause = {k: v for k, v in columns_and_where_clause.items() if v}
-        where_clause['deleted'] = None
 
         columns = list(columns_and_where_clause.keys())
 

--- a/pylintrc
+++ b/pylintrc
@@ -2,3 +2,6 @@
 min-similarity-lines=8
 ignore-imports=yes
 max-line-length=120
+
+[MESSAGES CONTROL]
+disable=super-with-arguments, raise-missing-from

--- a/tests/core/client_test.py
+++ b/tests/core/client_test.py
@@ -303,4 +303,4 @@ class TestClient(TestCase):
             client.update(class_type, params, post_body)
         except PMClientError as ex:
             self.assertTrue('301' in str(ex))
-            self.assertTrue('This is the error.'in str(ex))
+            self.assertTrue('This is the error.' in str(ex))

--- a/tests/core/cmd_test.py
+++ b/tests/core/cmd_test.py
@@ -60,6 +60,8 @@ def requests_retry_session(retries=3, backoff_factor=0.5, status_forcelist=(500,
 # The complication here is that older versions of the metadata service can't install
 # in Python versions > 3.7. The psycopg2 package required for those older versions
 # do not compile against Python > 3.7.
+
+
 @pytest.mark.skipif(sys.version_info > (3, 8), reason='requires python3.7 or less')
 class AdminCmdBase:
     """Test base class for setting up update environments."""


### PR DESCRIPTION
One minor change to make the object hash generator pull the correct set of data (that ignores deleted records)

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
